### PR TITLE
Fix inventory slot drawing to use initialized sprite

### DIFF
--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -158,14 +158,14 @@ function inv_draw_tooltip()
 }
 /* 
 * Name: inv_draw_slots
-* Description: Draw slot frames using global.spr_slot, scaled to slot size.
+* Description: Draw slot frames using global.inv_spr_slot, scaled to slot size.
 */
 function inv_draw_slots() {
     var _o = inv_panel_get_origin();
     var _left = _o.x;
     var _top  = _o.y;
 
-    var _sp     = global.spr_slot;
+    var _sp     = global.inv_spr_slot;
     var _sp_w   = sprite_get_width(_sp);
     var _sp_h   = sprite_get_height(_sp);
     var _scaleX = (_sp_w > 0) ? (global.inv_slot_w / _sp_w) : 1;


### PR DESCRIPTION
## Summary
- Draw inventory slot frames using `global.inv_spr_slot`

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c11a5c72e483329170a294f7ca5e10