### PR TITLE
Fix struct origin and sprite reference in inventory draw

### DIFF
--- a/objects/obj_inventory/Draw_64.gml
+++ b/objects/obj_inventory/Draw_64.gml
@@ -8,7 +8,7 @@ if (!global.inv_visible) exit;
 var _o = inv_panel_get_origin();
 draw_set_halign(fa_left);
 draw_set_valign(fa_top);
-draw_text(_o[0], _o[1] - 24, "Inventory");
+draw_text(_o.x, _o.y - 24, "Inventory");
 
 // Main UI
 inv_draw_all();

--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -156,16 +156,16 @@ function inv_draw_tooltip()
     draw_set_color(c_white);
     draw_text(m.x + 12 + pad, m.y + 12 + pad, name);
 }
-/* 
+/*
 * Name: inv_draw_slots
-* Description: Draw slot frames using global.spr_slot, scaled to slot size.
+* Description: Draw slot frames using global.inv_spr_slot, scaled to slot size.
 */
 function inv_draw_slots() {
     var _o = inv_panel_get_origin();
-    var _left = _o[0];
-    var _top  = _o[1];
+    var _left = _o.x;
+    var _top  = _o.y;
 
-    var _sp     = global.spr_slot;
+    var _sp     = global.inv_spr_slot;
     var _sp_w   = sprite_get_width(_sp);
     var _sp_h   = sprite_get_height(_sp);
     var _scaleX = (_sp_w > 0) ? (global.inv_slot_w / _sp_w) : 1;


### PR DESCRIPTION
## Summary
- Reference `inv_panel_get_origin` results via `x` and `y` fields when drawing slots
- Use struct field access for inventory title positioning
- Read slot frame sprite from `global.inv_spr_slot` to prevent undefined variable errors

## Testing
- `rg -n "global\\.spr_slot" -g "*.gml"`
- `rg -n "inv_spr_slot" -g "*.gml"`

------
https://chatgpt.com/codex/tasks/task_e_68c0f91fdbf483328805ca56aebf8c80