### PR TITLE
Handle missing sprite in inventory slot drawing

### DIFF
--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -165,7 +165,12 @@ function inv_draw_slots() {
     var _left = _o.x;
     var _top  = _o.y;
 
-    var _sp     = global.inv_spr_slot;
+    var _sp = global.inv_spr_slot;
+    if (_sp == -1) {
+        // No slot sprite available; nothing to draw
+        return;
+    }
+
     var _sp_w   = sprite_get_width(_sp);
     var _sp_h   = sprite_get_height(_sp);
     var _scaleX = (_sp_w > 0) ? (global.inv_slot_w / _sp_w) : 1;


### PR DESCRIPTION
## Summary
- Avoid invalid sprite_get_height errors by early returning when the inventory slot sprite is missing.

## Testing
- `npm test` (fails: command not found)
- `make test` (fails: No rule to make target `test`)


------
https://chatgpt.com/codex/tasks/task_e_68c11b9122b0833295a9c7c06a030b52