### PR TITLE
Fix inventory slot access and drag state handling

### DIFF
--- a/objects/obj_inventory/Step_0.gml
+++ b/objects/obj_inventory/Step_0.gml
@@ -12,63 +12,64 @@
     if (mouse_check_button_pressed(mb_left)) {
         var _idx = inv_hit_test();
         if (_idx != -1) {
-            var _stack = global.inventory_slots[_idx];
+            var _stack = INVENTORY_SLOTS[_idx];
             if (_stack.id != ItemId.None && _stack.count > 0) {
-                global.inv_drag_active = true;
-                global.inv_drag_stack  = _stack;
+                inv_drag_active_set(true);
+                inv_drag_stack_set(_stack);
                 global.inv_drag_from   = _idx;
                 // clear slot while dragging
-                global.inventory_slots[_idx] = { id: ItemId.None, count: 0 };
+                INVENTORY_SLOTS[_idx] = { id: ItemId.None, count: 0 };
             }
         }
     }
 
     // Drop/merge on LMB release
-    if (mouse_check_button_released(mb_left) && global.inv_drag_active) {
+    if (mouse_check_button_released(mb_left) && inv_drag_active_get()) {
         var _drop_idx = inv_hit_test();
         if (_drop_idx != -1) {
             // Try merge via rule logic first (if defined)
             if (!inv_try_merge_drag_into_slot(_drop_idx)) {
                 // If merge failed: place into empty or swap with occupant
-                var _dst = global.inventory_slots[_drop_idx];
+                var _dst = INVENTORY_SLOTS[_drop_idx];
                 if (_dst.id == ItemId.None || _dst.count <= 0) {
-                    global.inventory_slots[_drop_idx] = global.inv_drag_stack;
-                    global.inv_drag_stack = { id: ItemId.None, count: 0 };
+                    INVENTORY_SLOTS[_drop_idx] = inv_drag_stack_get();
+                    inv_drag_stack_set({ id: ItemId.None, count: 0 });
                 } else {
                     // swap
                     var _tmp = _dst;
-                    global.inventory_slots[_drop_idx] = global.inv_drag_stack;
-                    global.inv_drag_stack            = _tmp;
+                    INVENTORY_SLOTS[_drop_idx] = inv_drag_stack_get();
+                    inv_drag_stack_set(_tmp);
                 }
             }
-            global.inv_drag_active = false;
+            inv_drag_active_set(false);
             global.inv_drag_from   = -1;
         } else {
             // If not dropped on the grid, return to source (or first empty)
             var _src = global.inv_drag_from;
-            if (_src >= 0 && _src < array_length(global.inventory_slots) && global.inventory_slots[_src].id == ItemId.None) {
-                global.inventory_slots[_src] = global.inv_drag_stack;
+            if (_src >= 0 && _src < array_length(INVENTORY_SLOTS) && INVENTORY_SLOTS[_src].id == ItemId.None) {
+                INVENTORY_SLOTS[_src] = inv_drag_stack_get();
             } else {
                 // fallback: find a place, else drop
-                var _s = global.inv_drag_stack;
+                var _s = inv_drag_stack_get();
                 inv_add(_s.id, _s.count, 0, 0, "", 0); // adds to any free slot (non-dropping variant)
             }
-            global.inv_drag_active = false;
+            inv_drag_active_set(false);
             global.inv_drag_from   = -1;
-            global.inv_drag_stack  = { id: ItemId.None, count: 0 };
+            inv_drag_stack_set({ id: ItemId.None, count: 0 });
         }
     }
 
     // Cancel drag with Escape or RMB
-    if (global.inv_drag_active && (keyboard_check_pressed(vk_escape) || mouse_check_button_pressed(mb_right))) {
+    if (inv_drag_active_get() && (keyboard_check_pressed(vk_escape) || mouse_check_button_pressed(mb_right))) {
         var _src2 = global.inv_drag_from;
-        if (_src2 >= 0 && _src2 < array_length(global.inventory_slots) && global.inventory_slots[_src2].id == ItemId.None) {
-            global.inventory_slots[_src2] = global.inv_drag_stack;
+        if (_src2 >= 0 && _src2 < array_length(INVENTORY_SLOTS) && INVENTORY_SLOTS[_src2].id == ItemId.None) {
+            INVENTORY_SLOTS[_src2] = inv_drag_stack_get();
         } else {
-            inv_add(global.inv_drag_stack.id, global.inv_drag_stack.count, 0, 0, "", 0);
+            var _st = inv_drag_stack_get();
+            inv_add(_st.id, _st.count, 0, 0, "", 0);
         }
-        global.inv_drag_active = false;
+        inv_drag_active_set(false);
         global.inv_drag_from   = -1;
-        global.inv_drag_stack  = { id: ItemId.None, count: 0 };
+        inv_drag_stack_set({ id: ItemId.None, count: 0 });
     }
 }

--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -189,8 +189,8 @@ function inv_draw_slots() {
 * Description: Draw item sprites in each occupied slot, scaled to fit while preserving aspect.
 */
 function inv_draw_items() {
-    for (var _i = 0; _i < array_length(global.inventory_slots); _i++) {
-        var _s = global.inventory_slots[_i];
+    for (var _i = 0; _i < array_length(INVENTORY_SLOTS); _i++) {
+        var _s = INVENTORY_SLOTS[_i];
         if (_s.id == ItemId.None || _s.count <= 0) continue;
 
         var _sp = item_get_sprite(_s.id);
@@ -228,8 +228,8 @@ function inv_draw_all() {
 * Description: Draw the sprite for the currently dragged stack at the GUI mouse position.
 */
 function inv_draw_cursor_stack() {
-    if (!global.inv_drag_active) return;
-    var _stack = global.inv_drag_stack;
+    if (!inv_drag_active_get()) return;
+    var _stack = inv_drag_stack_get();
     if (_stack.id == ItemId.None || _stack.count <= 0) return;
 
     var _sp = item_get_sprite(_stack.id);

--- a/scripts/scr_inventory/scr_inventory.gml
+++ b/scripts/scr_inventory/scr_inventory.gml
@@ -47,10 +47,18 @@ function inventory_boot(_slot_count)
         }
     }
 
-    // Drag stack
+    // Drag helpers
     if (!variable_struct_exists(global.Inventory, "drag"))
     {
         global.Inventory.drag = inv_empty();
+    }
+    if (!variable_struct_exists(global.Inventory, "drag_active"))
+    {
+        global.Inventory.drag_active = false;
+    }
+    if (!variable_global_exists("inv_drag_from"))
+    {
+        global.inv_drag_from = -1;
     }
 }
 

--- a/scripts/scr_items/scr_items.gml
+++ b/scripts/scr_items/scr_items.gml
@@ -254,8 +254,8 @@ function inv_apply_merge(_src_stack, _dst_stack, _rule) {
 * Description: Attempts to merge the globally dragged stack into a given slot index.
 */
 function inv_try_merge_drag_into_slot(_slot_index) {
-    var dst = global.inventory_slots[_slot_index];
-    var src = global.inv_drag_stack;
+    var dst = INVENTORY_SLOTS[_slot_index];
+    var src = inv_drag_stack_get();
 
     var rule = inv_can_merge(src, dst);
     if (is_undefined(rule)) return false;
@@ -263,8 +263,8 @@ function inv_try_merge_drag_into_slot(_slot_index) {
     var outcome = inv_apply_merge(src, dst, rule);
     if (is_undefined(outcome)) return false;
 
-    global.inventory_slots[_slot_index] = outcome.dst_after;
-    global.inv_drag_stack = outcome.src_after;
+    INVENTORY_SLOTS[_slot_index] = outcome.dst_after;
+    inv_drag_stack_set(outcome.src_after);
     return true;
 }
 


### PR DESCRIPTION
## Summary
- use `INVENTORY_SLOTS` and drag helpers instead of undefined globals
- initialize inventory drag state on boot
- update inventory step logic to respect new API

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c11c78e8bc8332b5e30e6d27103e8f