### PR TITLE
chore: add npm test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node modules
+node_modules/
+
 # Windows
  
 # Windows thumbnail cache files

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Slime-Game
 All is Slime
+
+## Testing
+
+This project uses Node's built-in test runner. To execute the test suite run:
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "slime-game",
+  "version": "1.0.0",
+  "description": "All is Slime",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "private": true
+}

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,6 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+test('basic arithmetic works', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add Node.js testing skeleton with built-in test runner
- document test usage and ignore node_modules directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c12030f57083329c2c0cc15aaf48a9