### PR TITLE
fix: initialize item sprites

### DIFF
--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -194,7 +194,7 @@ function invDrawItems() {
         if (_s.id == ItemId.None || _s.count <= 0) continue;
 
         var _sp = itemGetSprite(_s.id);
-        if (_sp == -1) continue;
+        if (_sp == noone) continue;
 
         var _pos = inv_get_slot_center(_i);
         var _cx  = _pos.xx;
@@ -233,7 +233,7 @@ function invDrawCursorStack() {
     if (_stack.id == ItemId.None || _stack.count <= 0) return;
 
     var _sp = itemGetSprite(_stack.id);
-    if (_sp == -1) return;
+    if (_sp == noone) return;
 
     var _mx = device_mouse_x_to_gui(0);
     var _my = device_mouse_y_to_gui(0);

--- a/scripts/scr_items/scr_items.gml
+++ b/scripts/scr_items/scr_items.gml
@@ -78,7 +78,7 @@ function itemDbInit() {
         name: "Slime 1",
         max_stack: 1,
         merge_rules: [ ruleMake(ItemId.Slime1, ItemId.Slime2, 1, 1, 1) ],
-        icon_sprite: noone,
+        icon_sprite: spr_slime_1,
         color_tint: c_white,
         desc: "Gloopy basics."
     });
@@ -87,7 +87,7 @@ function itemDbInit() {
         name: "Slime 2",
         max_stack: 1,
         merge_rules: [ ruleMake(ItemId.Slime2, ItemId.Slime3, 1, 1, 1) ],
-        icon_sprite: noone,
+        icon_sprite: spr_slime_2,
         color_tint: c_white,
         desc: "Thicker ooze."
     });
@@ -96,7 +96,7 @@ function itemDbInit() {
         name: "Slime 3",
         max_stack: 1,
         merge_rules: [],
-        icon_sprite: noone,
+        icon_sprite: spr_slime_3,
         color_tint: c_white,
         desc: "Potent sludge."
     });
@@ -282,14 +282,12 @@ function itemGetMaxStack(_id)
 
 /*
 * Name: itemGetSprite
-* Description: Map ItemId → sprite resource used in the inventory UI. Returns -1 if unknown.
+* Description: Returns the icon sprite for the given item id from the DB, or `noone` if unknown.
 */
 function itemGetSprite(_id) {
-    switch (_id) {
-        case ItemId.Slime1: return global.sprItemSlime1;
-        case ItemId.Slime2: return global.sprItemSlime2;
-        case ItemId.Slime3: return global.sprItemSlime3;
-        default:            return -1;
-    }
+    var _def = itemGetDef(_id);
+    if (is_undefined(_def)) return noone;
+    if (is_undefined(_def.icon_sprite) || _def.icon_sprite == noone) return noone;
+    return _def.icon_sprite;
 }
 


### PR DESCRIPTION
## Summary
- associate slime items with their sprite resources in the item database
- load inventory sprites from the item DB instead of undefined globals
- use `noone` as the sentinel for missing item sprites

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11f6c0fa48332a7064664b813ac3f