### PR TITLE
Rewrite inventory system with keyboard navigation

### DIFF
--- a/objects/obj_inventory/Step_0.gml
+++ b/objects/obj_inventory/Step_0.gml
@@ -8,6 +8,38 @@
     var _mx = device_mouse_x_to_gui(0);
     var _my = device_mouse_y_to_gui(0);
 
+    // Keyboard navigation for active slot
+    var _a = global.invActiveSlot;
+    var _row = _a div INV_COLS;
+    var _col = _a mod INV_COLS;
+    if (keyboard_check_pressed(INV_KEY_UP))    _row = max(0, _row - 1);
+    if (keyboard_check_pressed(INV_KEY_DOWN))  _row = min(INV_ROWS - 1, _row + 1);
+    if (keyboard_check_pressed(INV_KEY_LEFT))  _col = max(0, _col - 1);
+    if (keyboard_check_pressed(INV_KEY_RIGHT)) _col = min(INV_COLS - 1, _col + 1);
+    global.invActiveSlot = _row * INV_COLS + _col;
+
+    // Selection via keyboard
+    if (keyboard_check_pressed(INV_KEY_SELECT)) {
+        var _idx = global.invActiveSlot;
+        if (global.invSelectSlot == -1) {
+            global.invSelectSlot = _idx;
+        } else if (global.invSelectSlot != _idx) {
+            var _a_stack = INVENTORY_SLOTS[global.invSelectSlot];
+            var _b_stack = INVENTORY_SLOTS[_idx];
+            var _rule = invCanMerge(_a_stack, _b_stack);
+            if (!is_undefined(_rule) && show_question("Merge items?")) {
+                var _out = invApplyMerge(_a_stack, _b_stack, _rule);
+                if (!is_undefined(_out)) {
+                    INVENTORY_SLOTS[_idx] = _out.dst_after;
+                    INVENTORY_SLOTS[global.invSelectSlot] = _out.src_after;
+                }
+            }
+            global.invSelectSlot = -1;
+        } else {
+            global.invSelectSlot = -1;
+        }
+    }
+
     // Begin drag on LMB press when a slot with items is clicked
     if (mouse_check_button_pressed(mb_left)) {
         var _idx = invHitTest();
@@ -26,32 +58,46 @@
     // Drop/merge on LMB release
     if (mouse_check_button_released(mb_left) && invDragActiveGet()) {
         var _drop_idx = invHitTest();
+        var _src_stack = invDragStackGet();
         if (_drop_idx != -1) {
-            // Try merge via rule logic first (if defined)
-            if (!invTryMergeDragIntoSlot(_drop_idx)) {
-                // If merge failed: place into empty or swap with occupant
-                var _dst = INVENTORY_SLOTS[_drop_idx];
+            var _dst = INVENTORY_SLOTS[_drop_idx];
+            var _rule = invCanMerge(_src_stack, _dst);
+            if (!is_undefined(_rule) && show_question("Merge items?")) {
+                var _out = invApplyMerge(_src_stack, _dst, _rule);
+                if (!is_undefined(_out)) {
+                    INVENTORY_SLOTS[_drop_idx] = _out.dst_after;
+                    invDragStackSet(_out.src_after);
+                }
+            } else if (is_undefined(_rule)) {
+                // If merge not possible: place into empty or swap with occupant
                 if (_dst.id == ItemId.None || _dst.count <= 0) {
-                    INVENTORY_SLOTS[_drop_idx] = invDragStackGet();
+                    INVENTORY_SLOTS[_drop_idx] = _src_stack;
                     invDragStackSet({ id: ItemId.None, count: 0 });
                 } else {
-                    // swap
                     var _tmp = _dst;
-                    INVENTORY_SLOTS[_drop_idx] = invDragStackGet();
+                    INVENTORY_SLOTS[_drop_idx] = _src_stack;
                     invDragStackSet(_tmp);
+                }
+            } else {
+                // Merge canceled: return to origin
+                var _src_idx = global.invDragFrom;
+                if (_src_idx >= 0 && _src_idx < array_length(INVENTORY_SLOTS) && INVENTORY_SLOTS[_src_idx].id == ItemId.None) {
+                    INVENTORY_SLOTS[_src_idx] = _src_stack;
+                } else {
+                    inv_add(_src_stack.id, _src_stack.count, 0, 0, "", 0);
                 }
             }
             invDragActiveSet(false);
             global.invDragFrom   = -1;
+            invDragStackSet({ id: ItemId.None, count: 0 });
         } else {
             // If not dropped on the grid, return to source (or first empty)
             var _src = global.invDragFrom;
             if (_src >= 0 && _src < array_length(INVENTORY_SLOTS) && INVENTORY_SLOTS[_src].id == ItemId.None) {
-                INVENTORY_SLOTS[_src] = invDragStackGet();
+                INVENTORY_SLOTS[_src] = _src_stack;
             } else {
                 // fallback: find a place, else drop
-                var _s = invDragStackGet();
-                inv_add(_s.id, _s.count, 0, 0, "", 0); // adds to any free slot (non-dropping variant)
+                inv_add(_src_stack.id, _src_stack.count, 0, 0, "", 0); // adds to any free slot (non-dropping variant)
             }
             invDragActiveSet(false);
             global.invDragFrom   = -1;

--- a/scripts/scr_boot/scr_boot.gml
+++ b/scripts/scr_boot/scr_boot.gml
@@ -45,7 +45,8 @@ function gameInit()
 
     // (Optional) Initialise subsystems if/when you add them; keep calls here:
     itemDbInit();
-    inventoryBoot(16);
+    // Allocate slots based on grid dimensions
+    inventoryBoot(INV_COLS * INV_ROWS);
     inventoryUiBoot(32,32);// UI layout: each slot 32x32 px
     inventorySkinBoot();
     // e.g., audio_init(), etc.

--- a/scripts/scr_draw_inventory/scr_draw_inventory.gml
+++ b/scripts/scr_draw_inventory/scr_draw_inventory.gml
@@ -165,22 +165,34 @@ function invDrawSlots() {
     var _left = _o.x;
     var _top  = _o.y;
 
-    var _sp = global.invSprSlot;
-    if (_sp == -1) {
+    var _base = global.invSprSlot;
+    if (_base == -1) {
         // No slot sprite available; nothing to draw
         return;
     }
 
-    var _sp_w   = sprite_get_width(_sp);
-    var _sp_h   = sprite_get_height(_sp);
+    var _sp_w   = sprite_get_width(_base);
+    var _sp_h   = sprite_get_height(_base);
     var _scaleX = (_sp_w > 0) ? (global.invSlotW / _sp_w) : 1;
     var _scaleY = (_sp_h > 0) ? (global.invSlotH / _sp_h) : 1;
 
+    var _hover  = invHitTest();
+    var _active = (variable_global_exists("invActiveSlot") ? global.invActiveSlot : -1);
+    var _sel    = (variable_global_exists("invSelectSlot") ? global.invSelectSlot : -1);
+
     for (var _r = 0; _r < INV_ROWS; _r++) {
         for (var _c = 0; _c < INV_COLS; _c++) {
+            var _idx = _r * INV_COLS + _c;
             var _cx = _left + _c * (global.invSlotW + INV_SLOT_PAD) + global.invSlotW * 0.5;
             var _cy = _top  + _r * (global.invSlotH + INV_SLOT_PAD) + global.invSlotH * 0.5;
-            draw_sprite_ext(_sp, 0, _cx, _cy, _scaleX, _scaleY, 0, c_white, 1);
+
+            var _spr = _base;
+            if (_idx == _active || _idx == _sel) {
+                if (global.invSprSlotSelect != -1) _spr = global.invSprSlotSelect;
+            } else if (_idx == _hover) {
+                if (global.invSprSlotHover != -1) _spr = global.invSprSlotHover;
+            }
+            draw_sprite_ext(_spr, 0, _cx, _cy, _scaleX, _scaleY, 0, c_white, 1);
         }
     }
 }

--- a/scripts/scr_globals/scr_globals.gml
+++ b/scripts/scr_globals/scr_globals.gml
@@ -6,10 +6,17 @@
 * Name: Inventory UI constants
 * Description: Grid layout and padding used by inventory panel & hit testing.
 */
-#macro INV_COLS         4        // number of columns in the grid
-#macro INV_ROWS         4        // number of rows in the grid
+#macro INV_COLS         8        // number of columns in the grid
+#macro INV_ROWS         8        // number of rows in the grid
 #macro INV_SLOT_PAD     4        // pixels between slots
 #macro INV_PANEL_MARGIN 12       // padding from screen edges
+
+// Default key bindings for inventory navigation (can be remapped)
+#macro INV_KEY_UP       ord("W")
+#macro INV_KEY_DOWN     ord("S")
+#macro INV_KEY_LEFT     ord("A")
+#macro INV_KEY_RIGHT    ord("D")
+#macro INV_KEY_SELECT   vk_enter
 
 /*
 * Name: InvAnchor

--- a/scripts/scr_inventory/scr_inventory.gml
+++ b/scripts/scr_inventory/scr_inventory.gml
@@ -60,6 +60,16 @@ function inventoryBoot(_slot_count)
     {
         global.invDragFrom = -1;
     }
+
+    // Active slot and selection tracker
+    if (!variable_global_exists("invActiveSlot"))
+    {
+        global.invActiveSlot = 0;
+    }
+    if (!variable_global_exists("invSelectSlot"))
+    {
+        global.invSelectSlot = -1;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- expand inventory to an 8x8 grid and expose configurable navigation keys
- highlight hovered and active slots, plus track active/selected slots
- add keyboard navigation and merge confirmation for selections or drag-drop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1250270ac83329c4c55a2a1dbdcea