### PR TITLE
Add player health and ammo systems

### DIFF
--- a/objects/obj_player/Collision_obj_enemy.gml
+++ b/objects/obj_player/Collision_obj_enemy.gml
@@ -1,0 +1,10 @@
+/*
+* Name: obj_player.Collision[obj_enemy]
+* Description: Apply damage with cooldown when touching enemies.
+*/
+if (damage_cd <= 0)
+{
+    hp -= 1;
+    damage_cd = 60;    // invulnerability frames
+    flash_timer = 15;  // flash white for a short time
+}

--- a/objects/obj_player/Create_0.gml
+++ b/objects/obj_player/Create_0.gml
@@ -3,3 +3,12 @@
 */
 input_locked = true;      // checked by input helpers
 alarm[0]     = 12;
+
+// --- Health & ammo init ---
+hp_max      = 3;
+hp          = hp_max;
+damage_cd   = 0;          // damage cooldown timer
+flash_timer = 0;          // white flash timer when hit
+
+ammo_max    = 10;
+ammo        = ammo_max;

--- a/objects/obj_player/Draw_0.gml
+++ b/objects/obj_player/Draw_0.gml
@@ -1,4 +1,23 @@
 // (Optional) Draw a tiny aim line to indicate direction
 var aim = inputGetAimAxis();
 draw_line_width(x, y, x + aim[0]*20, y + aim[1]*20, 2);
-draw_self();
+
+if (flash_timer > 0) {
+    gpu_set_blendmode(bm_add);
+    draw_self();
+    gpu_set_blendmode(bm_normal);
+} else {
+    draw_self();
+}
+
+// Draw health hearts
+var heart_x = 10;
+var heart_y = 10;
+draw_set_color(c_white);
+for (var i = 0; i < hp_max; i++) {
+    var heart_char = (i < hp) ? "\u2665" : "\u2661"; // ♥ or ♡
+    draw_text(heart_x + i * 16, heart_y, heart_char);
+}
+
+// Draw ammo
+draw_text(10, heart_y + 16, "Ammo: " + string(ammo));

--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -10,6 +10,14 @@
 // ----- Early pause gate (safe no-op hook) -----
 if (onPauseExit()) exit;
 
+// Update damage cooldowns
+if (damage_cd > 0) damage_cd -= 1;
+if (flash_timer > 0) flash_timer -= 1;
+if (hp <= 0) {
+    instance_destroy();
+    exit;
+}
+
 // ----- Gather input -----
 var mv  = inputGetMove();            // {dx,dy} WASD / arrows
 var aih = inputGetAimHeld();        // {dx,dy} IJKL held

--- a/objects/obj_player/obj_player.yy
+++ b/objects/obj_player/obj_player.yy
@@ -7,6 +7,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_slime_1","path":"objects/obj_slime_1/obj_slime_1.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_slime_2","path":"objects/obj_slime_2/obj_slime_2.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_enemy","path":"objects/obj_enemy/obj_enemy.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -19,6 +19,8 @@ function weaponTickCooldown(inst)
 function weaponTryFire(owner, origin_x, origin_y, aim_dx, aim_dy)
 {
     if (owner.fire_cd > 0) return false;
+    if (!variable_instance_exists(owner, "ammo")) owner.ammo = 0;
+    if (owner.ammo <= 0) return false; // no ammo
 
     // Normalise incoming aim
     var n = vec2Norm(aim_dx, aim_dy);
@@ -54,5 +56,6 @@ function weaponTryFire(owner, origin_x, origin_y, aim_dx, aim_dy)
 
     // Reset cooldown
     owner.fire_cd = FIRE_COOLDOWN_STEPS;
+    owner.ammo -= 1;
     return true;
 }


### PR DESCRIPTION
## Summary
- Give player 3-heart health and ammo values
- Show hearts and ammo on screen and add damage flash effect
- Consume ammo when firing and add cooldown between enemy hits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2429506d48332a953f2b921c88f4a