### PR TITLE
Fix HUD alignment and add death retry dialog

### DIFF
--- a/objects/obj_player/Draw_0.gml
+++ b/objects/obj_player/Draw_0.gml
@@ -9,15 +9,3 @@ if (flash_timer > 0) {
 } else {
     draw_self();
 }
-
-// Draw health hearts
-var heart_x = 10;
-var heart_y = 10;
-draw_set_color(c_white);
-for (var i = 0; i < hp_max; i++) {
-    var heart_char = (i < hp) ? "\u2665" : "\u2661"; // ♥ or ♡
-    draw_text(heart_x + i * 16, heart_y, heart_char);
-}
-
-// Draw ammo
-draw_text(10, heart_y + 16, "Ammo: " + string(ammo));

--- a/objects/obj_player/Draw_64.gml
+++ b/objects/obj_player/Draw_64.gml
@@ -1,0 +1,13 @@
+/*
+ * Name: obj_player.Draw GUI
+ * Description: Draw health and ammo HUD in GUI coordinates.
+ */
+var heart_x = 10;
+var heart_y = 10;
+draw_set_color(c_white);
+for (var i = 0; i < hp_max; i++) {
+    var heart_char = (i < hp) ? "\u2665" : "\u2661"; // ♥ or ♡
+    draw_text(heart_x + i * 16, heart_y, heart_char);
+}
+
+draw_text(10, heart_y + 16, "Ammo: " + string(ammo));

--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -14,6 +14,7 @@ if (onPauseExit()) exit;
 if (damage_cd > 0) damage_cd -= 1;
 if (flash_timer > 0) flash_timer -= 1;
 if (hp <= 0) {
+    dialogQueuePushQuestion("You died! Retry or quit?", function() { room_restart(); }, function() { game_end(); });
     instance_destroy();
     exit;
 }

--- a/objects/obj_player/obj_player.yy
+++ b/objects/obj_player/obj_player.yy
@@ -5,6 +5,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":64,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_slime_1","path":"objects/obj_slime_1/obj_slime_1.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_slime_2","path":"objects/obj_slime_2/obj_slime_2.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_enemy","path":"objects/obj_enemy/obj_enemy.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},


### PR DESCRIPTION
## Summary
- Anchor health and ammo HUD to screen via Draw GUI event
- Extend dialog system with Retry/Quit question capability
- Show Retry or Quit dialog when player dies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c245f02f3483329ef2bb78266f7f98