### PR TITLE
Handle optional dialog callbacks

### DIFF
--- a/scripts/scr_dialog/scr_dialog.gml
+++ b/scripts/scr_dialog/scr_dialog.gml
@@ -43,8 +43,18 @@ function dialogShowNext() {
 
     global.dialogCurrent = _entry.text;
     global.dialogType    = _entry.type;
-    global.dialogCbRetry = _entry.retry_cb;
-    global.dialogCbQuit  = _entry.quit_cb;
+
+    if (variable_struct_exists(_entry, "retry_cb")) {
+        global.dialogCbRetry = _entry.retry_cb;
+    } else {
+        global.dialogCbRetry = undefined;
+    }
+
+    if (variable_struct_exists(_entry, "quit_cb")) {
+        global.dialogCbQuit = _entry.quit_cb;
+    } else {
+        global.dialogCbQuit = undefined;
+    }
 
     global.dialogVisible = true;
     recomputePauseState(); // pause while visible


### PR DESCRIPTION
## Summary
- prevent missing variable errors when dialog entries lack callbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c24719b1a0833292868eac3fa8c9ee