### PR TITLE
Ensure HUD draws in GUI space

### DIFF
--- a/objects/obj_player/Draw_64.gml
+++ b/objects/obj_player/Draw_64.gml
@@ -1,13 +1,27 @@
 /*
  * Name: obj_player.Draw GUI
- * Description: Draw health and ammo HUD in GUI coordinates.
+ * Description: Draw health and ammo HUD using GUI coordinates so that it
+ * remains fixed on the screen regardless of the camera position.
  */
-var heart_x = 10;
-var heart_y = 10;
+
+// Fetch GUI dimensions in case the window or view size changes
+var gui_w = display_get_gui_width();
+
+// Margin from the screen edges
+var margin  = 10;
+var heart_x = margin;
+var heart_y = margin;
+
 draw_set_color(c_white);
+
+// Draw hearts representing current and maximum health
 for (var i = 0; i < hp_max; i++) {
     var heart_char = (i < hp) ? "\u2665" : "\u2661"; // ♥ or ♡
     draw_text(heart_x + i * 16, heart_y, heart_char);
 }
 
-draw_text(10, heart_y + 16, "Ammo: " + string(ammo));
+// Draw ammo text anchored to the top-right corner
+var ammo_text = "Ammo: " + string(ammo);
+draw_set_halign(fa_right);
+draw_text(gui_w - margin, heart_y + 16, ammo_text);
+draw_set_halign(fa_left);


### PR DESCRIPTION
## Summary
- Anchor health and ammo HUD using GUI dimensions so it stays visible regardless of camera movement.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2567f362c8332b420e8e605e961d1