### PR TITLE
Fix death dialog queue and display health count

### DIFF
--- a/objects/obj_player/Draw_64.gml
+++ b/objects/obj_player/Draw_64.gml
@@ -9,19 +9,18 @@ var gui_w = display_get_gui_width();
 
 // Margin from the screen edges
 var margin  = 10;
-var heart_x = margin;
-var heart_y = margin;
+var text_x = margin;
+var text_y = margin;
 
+draw_set_font(fnt_ui);
 draw_set_color(c_white);
 
-// Draw hearts representing current and maximum health
-for (var i = 0; i < hp_max; i++) {
-    var heart_char = (i < hp) ? "\u2665" : "\u2661"; // ♥ or ♡
-    draw_text(heart_x + i * 16, heart_y, heart_char);
-}
+// Draw numeric health so it's visible even without heart glyphs
+var health_text = "Health: " + string(hp) + " / " + string(hp_max);
+draw_text(text_x, text_y, health_text);
 
 // Draw ammo text anchored to the top-right corner
 var ammo_text = "Ammo: " + string(ammo);
 draw_set_halign(fa_right);
-draw_text(gui_w - margin, heart_y + 16, ammo_text);
+draw_text(gui_w - margin, text_y + 16, ammo_text);
 draw_set_halign(fa_left);

--- a/scripts/scr_dialog/scr_dialog.gml
+++ b/scripts/scr_dialog/scr_dialog.gml
@@ -3,7 +3,10 @@
 * Description: Initialise global dialogue state and queue. Call at boot.
 */
 function dialogInit() {
-    if (!variable_global_exists("dialogQueue")) global.dialogQueue = [];
+    // Ensure the queue exists and is a proper array each time we init.
+    if (!variable_global_exists("dialogQueue") || !is_array(global.dialogQueue)) {
+        global.dialogQueue = [];
+    }
     global.dialogVisible = false;
     global.dialogCurrent = "";
     global.dialogType = "";


### PR DESCRIPTION
## Summary
- Reset dialog queue to an array whenever it's not valid to prevent crash on player death
- Display player health numerically in GUI so it's visible without heart glyphs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2580efa6c83329e154d2d09082833