### PR TITLE
Respect collision tilemap in enemy spawner

### DIFF
--- a/objects/obj_spawner/Create_0.gml
+++ b/objects/obj_spawner/Create_0.gml
@@ -1,0 +1,3 @@
+/* Description: Cache collision tilemap layer id for spawn checks */
+tilemap_id = layer_tilemap_get_id("tm_collision");
+

--- a/objects/obj_spawner/Step_0.gml
+++ b/objects/obj_spawner/Step_0.gml
@@ -1,11 +1,36 @@
-/* Description: Spawn enemies at interval
+/* Description: Spawn enemies at interval while respecting collision tilemap
  *   Input: none
  *   Output: none
  */
 if (global.isPaused) exit;
 spawn_timer--;
 if (spawn_timer <= 0) {
-    var child = choose(obj_enemy_1, obj_enemy_2);
-    instance_create_layer(x + irandom_range(-200,200), y + irandom_range(-200,200), layer, child);
+    var child    = choose(obj_enemy_1, obj_enemy_2);
+    var attempts = 10;
+    while (attempts > 0) {
+        var sx = x + irandom_range(-200, 200);
+        var sy = y + irandom_range(-200, 200);
+
+        var blocked = false;
+        if (tilemap_id != -1) {
+            var steps = ceil(point_distance(x, y, sx, sy) / 16);
+            for (var i = 0; i <= steps; i++) {
+                var t  = i / steps;
+                var px = lerp(x,  sx, t);
+                var py = lerp(y,  sy, t);
+                if (tilemapSolidAt(tilemap_id, px, py)) {
+                    blocked = true;
+                    break;
+                }
+            }
+        }
+
+        if (!blocked) {
+            instance_create_layer(sx, sy, layer, child);
+            break;
+        }
+
+        attempts--;
+    }
     spawn_timer = irandom_range(60, 180);
 }


### PR DESCRIPTION
## Summary
- Cache collision tilemap id for the spawner
- Avoid spawning enemies beyond walls by checking the collision tilemap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25e5b5dd483329422e89ae9292a81