### PR TITLE
Prevent IJKL aim from rotating player sprite

### DIFF
--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -50,7 +50,14 @@ if (approxZero(facing_x, 0.00001) && approxZero(facing_y, 0.00001))
     facing_x = new_face[0];
     facing_y = new_face[1];
 }
-image_angle = point_direction(0,0, facing_x, facing_y);
+
+// ----- Sprite orientation -----
+// Only update the sprite angle when the player moves so that
+// IJKL aiming does not rotate the sprite.
+if (!approxZero(mv.dx, 0.00001) || !approxZero(mv.dy, 0.00001))
+{
+    image_angle = point_direction(0, 0, mv.dx, mv.dy);
+}
 
 // ----- Dash -----
 if (dash_cooldown > 0) dash_cooldown -= 1;


### PR DESCRIPTION
## Summary
- Stop IJKL aiming from rotating the player sprite by basing sprite orientation on movement input only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25fbdc22883329bb7c5eedd94d3a0