### PR TITLE
Customize enemy drop loot

### DIFF
--- a/objects/obj_enemy/Create_0.gml
+++ b/objects/obj_enemy/Create_0.gml
@@ -21,6 +21,11 @@ target           = noone;
 ammo_drop_min   = 3;   // minimum ammo pickups
 ammo_drop_max   = 5;   // maximum ammo pickups
 
+// Slime drop configuration
+slime_drop_object = obj_slime_1; // default slime pickup object
+slime_drop_min    = 1;           // minimum slime pickups
+slime_drop_max    = 3;           // maximum slime pickups
+
 /*
 * Name: obj_enemy.Create (base init)
 * Description: Initialise enemy defaults and cache collision tilemap.

--- a/objects/obj_enemy/Step_0.gml
+++ b/objects/obj_enemy/Step_0.gml
@@ -27,8 +27,8 @@ if (instance_exists(target)) {
 
 // Die if hp <= 0 → drop slime
 if (hp <= 0) {
-    // Create slime pickup with 1–3 items
-    var drop = instance_create_layer(x, y, layer, obj_slime);
-    drop.amount = irandom_range(1, 3);
+    // Create slime pickup with configured amount
+    var drop = instance_create_layer(x, y, layer, slime_drop_object);
+    drop.amount = irandom_range(slime_drop_min, slime_drop_max);
     instance_destroy();
 }

--- a/objects/obj_enemy_1/Create_0.gml
+++ b/objects/obj_enemy_1/Create_0.gml
@@ -13,3 +13,10 @@ is_dead = false;
 enemy_speed = 0.9;
 enemy_range = 160;
 
+// Override drop configuration
+ammo_drop_min   = 1;
+ammo_drop_max   = 2;
+slime_drop_object = obj_slime_1;
+slime_drop_min    = 1;
+slime_drop_max    = 1;
+

--- a/objects/obj_enemy_2/Create_0.gml
+++ b/objects/obj_enemy_2/Create_0.gml
@@ -13,3 +13,10 @@ is_dead = false;
 enemy_speed = 2;
 enemy_range = 200;
 
+// Override drop configuration
+ammo_drop_min   = 3;
+ammo_drop_max   = 4;
+slime_drop_object = obj_slime_2;
+slime_drop_min    = 1;
+slime_drop_max    = 1;
+


### PR DESCRIPTION
## Summary
- Add configurable slime drop object and amounts for enemies
- Enemy_1 drops 1-2 ammo and a single slime_1
- Enemy_2 drops 3-4 ammo and a single slime_2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c39f0171848332b8874d26d8028806