### PR TITLE
Implement enemy hurt feedback and AI state machine

### DIFF
--- a/docs/documentation/functions.html
+++ b/docs/documentation/functions.html
@@ -204,18 +204,20 @@
     
     <section class="card">
       <h2>Overview</h2>
-      <p>This reference covers <strong>106</strong> documented functions across <strong>13</strong> script assets.</p>
+      <p>This reference covers <strong>125</strong> documented functions across <strong>15</strong> script assets.</p>
       <nav aria-label="Function groups">
         <ul>
           <li><a href="#script-scr-boot">scr_boot <span class="badge">2</span></a></li>
 <li><a href="#script-scr-dash">scr_dash <span class="badge">3</span></a></li>
 <li><a href="#script-scr-dialog">scr_dialog <span class="badge">8</span></a></li>
 <li><a href="#script-scr-draw-inventory">scr_draw_inventory <span class="badge">11</span></a></li>
-<li><a href="#script-scr-enemy">scr_enemy <span class="badge">6</span></a></li>
+<li><a href="#script-scr-enemy">scr_enemy <span class="badge">10</span></a></li>
 <li><a href="#script-scr-input">scr_input <span class="badge">7</span></a></li>
 <li><a href="#script-scr-inventory">scr_inventory <span class="badge">14</span></a></li>
-<li><a href="#script-scr-items">scr_items <span class="badge">14</span></a></li>
+<li><a href="#script-scr-items">scr_items <span class="badge">16</span></a></li>
 <li><a href="#script-scr-menu">scr_menu <span class="badge">5</span></a></li>
+<li><a href="#script-scr-pickups">scr_pickups <span class="badge">10</span></a></li>
+<li><a href="#script-scr-player-stats">scr_player_stats <span class="badge">3</span></a></li>
 <li><a href="#script-scr-pmove">scr_pmove <span class="badge">4</span></a></li>
 <li><a href="#script-scr-room-generation">scr_room_generation <span class="badge">15</span></a></li>
 <li><a href="#script-scr-utils">scr_utils <span class="badge">15</span></a></li>
@@ -380,7 +382,7 @@
   <p><code>function invDrawAll()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_draw_inventory/scr_draw_inventory.gml:253</span>
+    <span title="Source path">📁 scripts/scr_draw_inventory/scr_draw_inventory.gml:254</span>
     <span title="Script asset">📄 scr_draw_inventory</span>
   </div>
 </article>
@@ -390,7 +392,7 @@
   <p><code>function invDrawCursorStack()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_draw_inventory/scr_draw_inventory.gml:261</span>
+    <span title="Source path">📁 scripts/scr_draw_inventory/scr_draw_inventory.gml:262</span>
     <span title="Script asset">📄 scr_draw_inventory</span>
   </div>
 </article>
@@ -477,13 +479,33 @@
 </section>
 <section id="script-scr-enemy">
   <h2>scr_enemy</h2>
-  <article class="card" id="function-enemybaseinit">
+  <article class="card" id="function-enemyapplydamage">
+  <h3>enemyApplyDamage</h3>
+  <p>Apply damage with stun/flash feedback and ensure the enemy becomes active.</p>
+  <p><code>function enemyApplyDamage(_amount, _source)</code></p>
+  <ul><li><code>_amount</code></li><li><code>_source</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:139</span>
+    <span title="Script asset">📄 scr_enemy</span>
+  </div>
+</article>
+<article class="card" id="function-enemybaseinit">
   <h3>enemyBaseInit</h3>
   <p>Initialise defaults, collider, tilemap, and fractional move remainders.</p>
   <p><code>function enemyBaseInit()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:35</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:45</span>
+    <span title="Script asset">📄 scr_enemy</span>
+  </div>
+</article>
+<article class="card" id="function-enemychasetarget">
+  <h3>enemyChaseTarget</h3>
+  <p>Move towards the provided target using tilemap-aware motion.</p>
+  <p><code>function enemyChaseTarget(_target)</code></p>
+  <ul><li><code>_target</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:114</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
@@ -493,17 +515,37 @@
   <p><code>function enemyResolveTilemap()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:88</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:227</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
 <article class="card" id="function-enemyseekplayerstep">
   <h3>enemySeekPlayerStep</h3>
-  <p>Avoid tiny oscillations when very close to the player.</p>
+  <p>Handle behaviour state transitions and chase the player when active.</p>
   <p><code>function enemySeekPlayerStep()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:58</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:182</span>
+    <span title="Script asset">📄 scr_enemy</span>
+  </div>
+</article>
+<article class="card" id="function-enemysetactive">
+  <h3>enemySetActive</h3>
+  <p>Activate the enemy and assign a chase target (defaults to nearest player).</p>
+  <p><code>function enemySetActive(_target)</code></p>
+  <ul><li><code>_target</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:97</span>
+    <span title="Script asset">📄 scr_enemy</span>
+  </div>
+</article>
+<article class="card" id="function-enemysetidle">
+  <h3>enemySetIdle</h3>
+  <p>Reset behaviour state to idle and clear movement remainders/target.</p>
+  <p><code>function enemySetIdle()</code></p>
+  <p class="empty">No parameters</p>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:86</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
@@ -513,7 +555,7 @@
   <p><code>function enemyUnstuckFromTilemap(_tm, _max)</code></p>
   <ul><li><code>_tm</code></li><li><code>_max</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:6</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:16</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
@@ -523,7 +565,7 @@
   <p><code>function moveAxisWithTilemap(_tm, _axis, _amount, _w, _h)</code></p>
   <ul><li><code>_tm</code></li><li><code>_axis</code></li><li><code>_amount</code></li><li><code>_w</code></li><li><code>_h</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:122</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:261</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
@@ -533,7 +575,7 @@
   <p><code>function tmRectHitsSolid(_tm, _x, _y, _w, _h)</code></p>
   <ul><li><code>_tm</code></li><li><code>_x</code></li><li><code>_y</code></li><li><code>_w</code></li><li><code>_h</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:97</span>
+    <span title="Source path">📁 scripts/scr_enemy/scr_enemy.gml:236</span>
     <span title="Script asset">📄 scr_enemy</span>
   </div>
 </article>
@@ -619,7 +661,7 @@
   <p><code>function invAddOrDrop(_id, _count, _wx, _wy, _layer_name)</code></p>
   <ul><li><code>_id</code></li><li><code>_count</code></li><li><code>_wx</code></li><li><code>_wy</code></li><li><code>_layer_name</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:149</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:137</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -629,7 +671,7 @@
   <p><code>function invDragActiveGet()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:207</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:195</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -639,7 +681,7 @@
   <p><code>function invDragActiveSet(_on)</code></p>
   <ul><li><code>_on</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:228</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:216</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -649,7 +691,7 @@
   <p><code>function invDragStackGet()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:217</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:205</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -659,7 +701,7 @@
   <p><code>function invDragStackSet(_stack)</code></p>
   <ul><li><code>_stack</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:238</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:226</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -689,7 +731,7 @@
   <p><code>function inventorySkinBoot()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:177</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:165</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -699,7 +741,7 @@
   <p><code>function inventoryUiBoot(_slot_w, _slot_h)</code></p>
   <ul><li><code>_slot_w</code></li><li><code>_slot_h</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:158</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:146</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -709,7 +751,7 @@
   <p><code>function invHide()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:257</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:245</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -719,7 +761,7 @@
   <p><code>function invShow()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:248</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:236</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -729,7 +771,7 @@
   <p><code>function invToggle()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:267</span>
+    <span title="Source path">📁 scripts/scr_inventory/scr_inventory.gml:255</span>
     <span title="Script asset">📄 scr_inventory</span>
   </div>
 </article>
@@ -762,7 +804,7 @@
   <p><code>function invApplyMerge(_src_stack, _dst_stack, _rule)</code></p>
   <ul><li><code>_src_stack</code></li><li><code>_dst_stack</code></li><li><code>_rule</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:221</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:266</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -772,7 +814,7 @@
   <p><code>function invCanMerge(_src_stack, _dst_stack)</code></p>
   <ul><li><code>_src_stack</code></li><li><code>_dst_stack</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:203</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:248</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -782,7 +824,7 @@
   <p><code>function invTryMergeDragIntoSlot(_slot_index)</code></p>
   <ul><li><code>_slot_index</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:256</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:301</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -792,7 +834,7 @@
   <p><code>function itemCoalesce(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:145</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:190</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -802,7 +844,7 @@
   <p><code>function itemDbGet(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:119</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:164</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -812,7 +854,7 @@
   <p><code>function itemDbInit()</code></p>
   <p class="empty">No parameters</p>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:54</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:57</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -822,7 +864,27 @@
   <p><code>function itemDbPut(_id, _def)</code></p>
   <ul><li><code>_id</code></li><li><code>_def</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:24</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:27</span>
+    <span title="Script asset">📄 scr_items</span>
+  </div>
+</article>
+<article class="card" id="function-itemgetbuffs">
+  <h3>itemGetBuffs</h3>
+  <p>Returns the buff struct for the item, or undefined.</p>
+  <p><code>function itemGetBuffs(_id)</code></p>
+  <ul><li><code>_id</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:354</span>
+    <span title="Script asset">📄 scr_items</span>
+  </div>
+</article>
+<article class="card" id="function-itemgetcolortint">
+  <h3>itemGetColorTint</h3>
+  <p>Returns configured tint colour for inventory/world visuals.</p>
+  <p><code>function itemGetColorTint(_id)</code></p>
+  <ul><li><code>_id</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:343</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -832,7 +894,7 @@
   <p><code>function itemGetDef(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:109</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:154</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -842,7 +904,7 @@
   <p><code>function itemGetMaxStack(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:275</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:320</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -852,7 +914,7 @@
   <p><code>function itemGetName(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:127</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:172</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -862,7 +924,7 @@
   <p><code>function itemGetSprite(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:287</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:332</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -872,7 +934,7 @@
   <p><code>function itemIsValid(_id)</code></p>
   <ul><li><code>_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:136</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:181</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -882,7 +944,7 @@
   <p><code>function itemMergeRuleLookup(_a_id, _b_id)</code></p>
   <ul><li><code>_a_id</code></li><li><code>_b_id</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:153</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:198</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -892,7 +954,7 @@
   <p><code>function ruleMake(_with_id, _result_id, _src_cost, _dst_cost, _result_count)</code></p>
   <ul><li><code>_with_id</code></li><li><code>_result_id</code></li><li><code>_src_cost</code></li><li><code>_dst_cost</code></li><li><code>_result_count</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_items/scr_items.gml:39</span>
+    <span title="Source path">📁 scripts/scr_items/scr_items.gml:42</span>
     <span title="Script asset">📄 scr_items</span>
   </div>
 </article>
@@ -947,6 +1009,142 @@
   <div class="meta">
     <span title="Source path">📁 scripts/scr_menu/scr_menu.gml:80</span>
     <span title="Script asset">📄 scr_menu</span>
+  </div>
+</article>
+</section>
+<section id="script-scr-pickups">
+  <h2>scr_pickups</h2>
+  <article class="card" id="function-pickupchoosemodifierid">
+  <h3>pickupChooseModifierId</h3>
+  <p>Resolves preferred modifier id or random fallback.</p>
+  <p><code>function pickupChooseModifierId(_preferred)</code></p>
+  <ul><li><code>_preferred</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:175</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupclampamount">
+  <h3>pickupClampAmount</h3>
+  <p>Returns a non-negative integer amount for stack counts.</p>
+  <p><code>function pickupClampAmount(_amt)</code></p>
+  <ul><li><code>_amt</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:19</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupcombineintoself">
+  <h3>pickupCombineIntoSelf</h3>
+  <p>Absorbs nearby pickups of the same type into _inst.</p>
+  <p><code>function pickupCombineIntoSelf(_inst)</code></p>
+  <ul><li><code>_inst</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:59</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupconfiguremodifier">
+  <h3>pickupConfigureModifier</h3>
+  <p>Applies modifier settings and merges duplicates.</p>
+  <p><code>function pickupConfigureModifier(_inst, _item_id, _amount)</code></p>
+  <ul><li><code>_inst</code></li><li><code>_item_id</code></li><li><code>_amount</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:125</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupconfigurestock">
+  <h3>pickupConfigureStock</h3>
+  <p>Applies stock settings and merges duplicates.</p>
+  <p><code>function pickupConfigureStock(_inst, _amount)</code></p>
+  <ul><li><code>_inst</code></li><li><code>_amount</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:102</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupplayercollect">
+  <h3>pickupPlayerCollect</h3>
+  <p>Applies pickup effects when the player collides with it.</p>
+  <p><code>function pickupPlayerCollect(_player, _pickup)</code></p>
+  <ul><li><code>_player</code></li><li><code>_pickup</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:214</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickuprefreshappearance">
+  <h3>pickupRefreshAppearance</h3>
+  <p>Updates sprite tint based on pickup class/item id.</p>
+  <p><code>function pickupRefreshAppearance(_inst)</code></p>
+  <ul><li><code>_inst</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:29</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupresolvelayer">
+  <h3>pickupResolveLayer</h3>
+  <p>Returns a safe layer name for spawning pickups.</p>
+  <p><code>function pickupResolveLayer(_layer_name)</code></p>
+  <ul><li><code>_layer_name</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:150</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupspawnmodifier">
+  <h3>pickupSpawnModifier</h3>
+  <p>Spawns a modifier pickup with the specified item id and amount.</p>
+  <p><code>function pickupSpawnModifier(_x, _y, _layer_name, _item_id, _amount)</code></p>
+  <ul><li><code>_x</code></li><li><code>_y</code></li><li><code>_layer_name</code></li><li><code>_item_id</code></li><li><code>_amount</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:199</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+<article class="card" id="function-pickupspawnstock">
+  <h3>pickupSpawnStock</h3>
+  <p>Spawns a stock pickup instance with the given amount.</p>
+  <p><code>function pickupSpawnStock(_x, _y, _layer_name, _amount)</code></p>
+  <ul><li><code>_x</code></li><li><code>_y</code></li><li><code>_layer_name</code></li><li><code>_amount</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_pickups/scr_pickups.gml:160</span>
+    <span title="Script asset">📄 scr_pickups</span>
+  </div>
+</article>
+</section>
+<section id="script-scr-player-stats">
+  <h2>scr_player_stats</h2>
+  <article class="card" id="function-playerstatsapplybuff">
+  <h3>playerStatsApplyBuff</h3>
+  <p>Applies a buff struct multiplied by count onto stats struct.</p>
+  <p><code>function playerStatsApplyBuff(_stats, _buff, _count)</code></p>
+  <ul><li><code>_stats</code></li><li><code>_buff</code></li><li><code>_count</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_player_stats/scr_player_stats.gml:30</span>
+    <span title="Script asset">📄 scr_player_stats</span>
+  </div>
+</article>
+<article class="card" id="function-playerstatsensurebase">
+  <h3>playerStatsEnsureBase</h3>
+  <p>Stores baseline stats for later modifier application.</p>
+  <p><code>function playerStatsEnsureBase(_inst)</code></p>
+  <ul><li><code>_inst</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_player_stats/scr_player_stats.gml:9</span>
+    <span title="Script asset">📄 scr_player_stats</span>
+  </div>
+</article>
+<article class="card" id="function-playerstatsrecalculate">
+  <h3>playerStatsRecalculate</h3>
+  <p>Rebuilds derived stats from current inventory contents.</p>
+  <p><code>function playerStatsRecalculate(_inst)</code></p>
+  <ul><li><code>_inst</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_player_stats/scr_player_stats.gml:49</span>
+    <span title="Script asset">📄 scr_player_stats</span>
   </div>
 </article>
 </section>
@@ -1323,7 +1521,7 @@
 </article>
 </section>
   
-    <footer>Generated on 2025-09-20T07:37:02.629Z</footer>
+    <footer>Generated on 2025-09-20T08:37:01.373Z</footer>
   </main>
 </body>
 </html>

--- a/docs/documentation/functions.md
+++ b/docs/documentation/functions.md
@@ -115,7 +115,7 @@ Resolve the collision tilemap from the layer named "tm_collision".
 Related: [enemyBaseInit](#enemybaseinit), [enemySeekPlayerStep](#enemyseekplayerstep), [enemyUnstuckFromTilemap](#enemyunstuckfromtilemap)
 
 ### enemySeekPlayerStep
-Avoid tiny oscillations when very close to the player.
+Handle behaviour state transitions and chase the player when active.
 Related: [enemyBaseInit](#enemybaseinit), [enemyResolveTilemap](#enemyresolvetilemap), [enemyUnstuckFromTilemap](#enemyunstuckfromtilemap)
 
 ### enemyUnstuckFromTilemap

--- a/docs/documentation/object-script-map.html
+++ b/docs/documentation/object-script-map.html
@@ -204,13 +204,12 @@
     
     <section class="card">
       <h2>Overview</h2>
-      <p>Script usage across <strong>17</strong> objects. Each badge indicates the script asset providing the function.</p>
+      <p>Script usage across <strong>16</strong> objects. Each badge indicates the script asset providing the function.</p>
       <nav aria-label="Object list">
         <ul>
-          <li><a href="#object-obj-ammo">obj_ammo <span class="badge">0</span></a></li>
-<li><a href="#object-obj-bullet">obj_bullet <span class="badge">1</span></a></li>
+          <li><a href="#object-obj-bullet">obj_bullet <span class="badge">2</span></a></li>
 <li><a href="#object-obj-dialog">obj_dialog <span class="badge">2</span></a></li>
-<li><a href="#object-obj-enemy">obj_enemy <span class="badge">3</span></a></li>
+<li><a href="#object-obj-enemy">obj_enemy <span class="badge">6</span></a></li>
 <li><a href="#object-obj-enemy-1">obj_enemy_1 <span class="badge">0</span></a></li>
 <li><a href="#object-obj-enemy-2">obj_enemy_2 <span class="badge">2</span></a></li>
 <li><a href="#object-obj-enemy-bullet">obj_enemy_bullet <span class="badge">1</span></a></li>
@@ -218,43 +217,21 @@
 <li><a href="#object-obj-game-controller">obj_game_controller <span class="badge">1</span></a></li>
 <li><a href="#object-obj-inventory">obj_inventory <span class="badge">10</span></a></li>
 <li><a href="#object-obj-menu-controller">obj_menu_controller <span class="badge">6</span></a></li>
-<li><a href="#object-obj-player">obj_player <span class="badge">16</span></a></li>
-<li><a href="#object-obj-slime-1">obj_slime_1 <span class="badge">0</span></a></li>
-<li><a href="#object-obj-slime-2">obj_slime_2 <span class="badge">0</span></a></li>
-<li><a href="#object-obj-slime-3">obj_slime_3 <span class="badge">0</span></a></li>
+<li><a href="#object-obj-pickup-base">obj_pickup_base <span class="badge">2</span></a></li>
+<li><a href="#object-obj-pickup-modifier">obj_pickup_modifier <span class="badge">1</span></a></li>
+<li><a href="#object-obj-pickup-stock">obj_pickup_stock <span class="badge">0</span></a></li>
+<li><a href="#object-obj-player">obj_player <span class="badge">17</span></a></li>
 <li><a href="#object-obj-spawner">obj_spawner <span class="badge">1</span></a></li>
 <li><a href="#object-obj-trigger">obj_trigger <span class="badge">0</span></a></li>
         </ul>
       </nav>
     </section>
-    <section id="object-obj-ammo">
-  <h2>obj_ammo</h2>
-  <div class="meta">
-    <span>📁 objects/obj_ammo</span>
-    <span>🧩 1 events</span>
-    <span>🛠️ 0 unique script functions</span>
-  </div>
-  <table>
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Script calls</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-  <td data-label="Event"><span title="objects/obj_ammo/Create_0.gml">Create → 0</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
-</tr>
-      </tbody>
-    </table>
-</section>
-<section id="object-obj-bullet">
+    <section id="object-obj-bullet">
   <h2>obj_bullet</h2>
   <div class="meta">
     <span>📁 objects/obj_bullet</span>
     <span>🧩 4 events</span>
-    <span>🛠️ 1 unique script functions</span>
+    <span>🛠️ 2 unique script functions</span>
   </div>
   <table>
       <thead>
@@ -266,11 +243,11 @@
       <tbody>
         <tr>
   <td data-label="Event"><span title="objects/obj_bullet/Collision_obj_enemy.gml">Collision → obj_enemy</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-enemyapplydamage">enemyApplyDamage</a> <span class="badge">scr_enemy</span></li></ul></td>
 </tr>
 <tr>
   <td data-label="Event"><span title="objects/obj_bullet/Collision_obj_enemy_parent.gml">Collision → obj_enemy_parent</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-enemyapplydamage">enemyApplyDamage</a> <span class="badge">scr_enemy</span></li></ul></td>
 </tr>
 <tr>
   <td data-label="Event"><span title="objects/obj_bullet/Create_0.gml">Create → 0</span></td>
@@ -317,8 +294,8 @@
   <h2>obj_enemy</h2>
   <div class="meta">
     <span>📁 objects/obj_enemy</span>
-    <span>🧩 2 events</span>
-    <span>🛠️ 3 unique script functions</span>
+    <span>🧩 3 events</span>
+    <span>🛠️ 6 unique script functions</span>
   </div>
   <table>
       <thead>
@@ -333,8 +310,12 @@
   <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-enemybaseinit">enemyBaseInit</a> <span class="badge">scr_enemy</span></li></ul></td>
 </tr>
 <tr>
+  <td data-label="Event"><span title="objects/obj_enemy/Draw_0.gml">Draw → 0</span></td>
+  <td data-label="Script calls"><span class="empty">No script functions</span></td>
+</tr>
+<tr>
   <td data-label="Event"><span title="objects/obj_enemy/Step_0.gml">Step → 0</span></td>
-  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-enemyseekplayerstep">enemySeekPlayerStep</a> <span class="badge">scr_enemy</span></li><li><a class="inline-link" href="functions.html#function-onpauseexit">onPauseExit</a> <span class="badge">scr_utils</span></li></ul></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-enemyseekplayerstep">enemySeekPlayerStep</a> <span class="badge">scr_enemy</span></li><li><a class="inline-link" href="functions.html#function-onpauseexit">onPauseExit</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-pickupchoosemodifierid">pickupChooseModifierId</a> <span class="badge">scr_pickups</span></li><li><a class="inline-link" href="functions.html#function-pickupspawnmodifier">pickupSpawnModifier</a> <span class="badge">scr_pickups</span></li><li><a class="inline-link" href="functions.html#function-pickupspawnstock">pickupSpawnStock</a> <span class="badge">scr_pickups</span></li></ul></td>
 </tr>
       </tbody>
     </table>
@@ -525,12 +506,69 @@
       </tbody>
     </table>
 </section>
+<section id="object-obj-pickup-base">
+  <h2>obj_pickup_base</h2>
+  <div class="meta">
+    <span>📁 objects/obj_pickup_base</span>
+    <span>🧩 2 events</span>
+    <span>🛠️ 2 unique script functions</span>
+  </div>
+  <table>
+      <thead>
+        <tr>
+          <th>Event</th>
+          <th>Script calls</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+  <td data-label="Event"><span title="objects/obj_pickup_base/Create_0.gml">Create → 0</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-pickupclampamount">pickupClampAmount</a> <span class="badge">scr_pickups</span></li><li><a class="inline-link" href="functions.html#function-pickuprefreshappearance">pickupRefreshAppearance</a> <span class="badge">scr_pickups</span></li></ul></td>
+</tr>
+<tr>
+  <td data-label="Event"><span title="objects/obj_pickup_base/Step_0.gml">Step → 0</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-pickupclampamount">pickupClampAmount</a> <span class="badge">scr_pickups</span></li></ul></td>
+</tr>
+      </tbody>
+    </table>
+</section>
+<section id="object-obj-pickup-modifier">
+  <h2>obj_pickup_modifier</h2>
+  <div class="meta">
+    <span>📁 objects/obj_pickup_modifier</span>
+    <span>🧩 1 events</span>
+    <span>🛠️ 1 unique script functions</span>
+  </div>
+  <table>
+      <thead>
+        <tr>
+          <th>Event</th>
+          <th>Script calls</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+  <td data-label="Event"><span title="objects/obj_pickup_modifier/Create_0.gml">Create → 0</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-pickuprefreshappearance">pickupRefreshAppearance</a> <span class="badge">scr_pickups</span></li></ul></td>
+</tr>
+      </tbody>
+    </table>
+</section>
+<section id="object-obj-pickup-stock">
+  <h2>obj_pickup_stock</h2>
+  <div class="meta">
+    <span>📁 objects/obj_pickup_stock</span>
+    <span>🧩 0 events</span>
+    <span>🛠️ 0 unique script functions</span>
+  </div>
+  <p class="empty">No events found for this object.</p>
+</section>
 <section id="object-obj-player">
   <h2>obj_player</h2>
   <div class="meta">
     <span>📁 objects/obj_player</span>
-    <span>🧩 9 events</span>
-    <span>🛠️ 16 unique script functions</span>
+    <span>🧩 7 events</span>
+    <span>🛠️ 17 unique script functions</span>
   </div>
   <table>
       <thead>
@@ -545,20 +583,12 @@
   <td data-label="Script calls"><span class="empty">No script functions</span></td>
 </tr>
 <tr>
-  <td data-label="Event"><span title="objects/obj_player/Collision_obj_ammo.gml">Collision → obj_ammo</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
-</tr>
-<tr>
   <td data-label="Event"><span title="objects/obj_player/Collision_obj_enemy.gml">Collision → obj_enemy</span></td>
   <td data-label="Script calls"><span class="empty">No script functions</span></td>
 </tr>
 <tr>
-  <td data-label="Event"><span title="objects/obj_player/Collision_obj_slime_1.gml">Collision → obj_slime_1</span></td>
-  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-invaddordrop">invAddOrDrop</a> <span class="badge">scr_inventory</span></li></ul></td>
-</tr>
-<tr>
-  <td data-label="Event"><span title="objects/obj_player/Collision_obj_slime_2.gml">Collision → obj_slime_2</span></td>
-  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-invaddordrop">invAddOrDrop</a> <span class="badge">scr_inventory</span></li></ul></td>
+  <td data-label="Event"><span title="objects/obj_player/Collision_obj_pickup_base.gml">Collision → obj_pickup_base</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-pickupplayercollect">pickupPlayerCollect</a> <span class="badge">scr_pickups</span></li></ul></td>
 </tr>
 <tr>
   <td data-label="Event"><span title="objects/obj_player/Create_0.gml">Create → 0</span></td>
@@ -574,73 +604,7 @@
 </tr>
 <tr>
   <td data-label="Event"><span title="objects/obj_player/Step_0.gml">Step → 0</span></td>
-  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-approxzero">approxZero</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-dialogqueuepushquestion">dialogQueuePushQuestion</a> <span class="badge">scr_dialog</span></li><li><a class="inline-link" href="functions.html#function-inputdashpressed">inputDashPressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputfireheld">inputFireHeld</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputfirepressed">inputFirePressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetaimheld">inputGetAimHeld</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetaimpressed">inputGetAimPressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetmove">inputGetMove</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-keeplastnonzerovec">keepLastNonzeroVec</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-onpauseexit">onPauseExit</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-pmoveapply">pmoveApply</a> <span class="badge">scr_pmove</span></li><li><a class="inline-link" href="functions.html#function-vec2norm">vec2Norm</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-weapontickcooldown">weaponTickCooldown</a> <span class="badge">scr_weapon</span></li><li><a class="inline-link" href="functions.html#function-weapontryfire">weaponTryFire</a> <span class="badge">scr_weapon</span></li></ul></td>
-</tr>
-      </tbody>
-    </table>
-</section>
-<section id="object-obj-slime-1">
-  <h2>obj_slime_1</h2>
-  <div class="meta">
-    <span>📁 objects/obj_slime_1</span>
-    <span>🧩 1 events</span>
-    <span>🛠️ 0 unique script functions</span>
-  </div>
-  <table>
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Script calls</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-  <td data-label="Event"><span title="objects/obj_slime_1/Create_0.gml">Create → 0</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
-</tr>
-      </tbody>
-    </table>
-</section>
-<section id="object-obj-slime-2">
-  <h2>obj_slime_2</h2>
-  <div class="meta">
-    <span>📁 objects/obj_slime_2</span>
-    <span>🧩 1 events</span>
-    <span>🛠️ 0 unique script functions</span>
-  </div>
-  <table>
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Script calls</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-  <td data-label="Event"><span title="objects/obj_slime_2/Create_0.gml">Create → 0</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
-</tr>
-      </tbody>
-    </table>
-</section>
-<section id="object-obj-slime-3">
-  <h2>obj_slime_3</h2>
-  <div class="meta">
-    <span>📁 objects/obj_slime_3</span>
-    <span>🧩 1 events</span>
-    <span>🛠️ 0 unique script functions</span>
-  </div>
-  <table>
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Script calls</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-  <td data-label="Event"><span title="objects/obj_slime_3/Create_0.gml">Create → 0</span></td>
-  <td data-label="Script calls"><span class="empty">No script functions</span></td>
+  <td data-label="Script calls"><ul><li><a class="inline-link" href="functions.html#function-approxzero">approxZero</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-dialogqueuepushquestion">dialogQueuePushQuestion</a> <span class="badge">scr_dialog</span></li><li><a class="inline-link" href="functions.html#function-inputdashpressed">inputDashPressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputfireheld">inputFireHeld</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputfirepressed">inputFirePressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetaimheld">inputGetAimHeld</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetaimpressed">inputGetAimPressed</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-inputgetmove">inputGetMove</a> <span class="badge">scr_input</span></li><li><a class="inline-link" href="functions.html#function-keeplastnonzerovec">keepLastNonzeroVec</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-onpauseexit">onPauseExit</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-playerstatsrecalculate">playerStatsRecalculate</a> <span class="badge">scr_player_stats</span></li><li><a class="inline-link" href="functions.html#function-pmoveapply">pmoveApply</a> <span class="badge">scr_pmove</span></li><li><a class="inline-link" href="functions.html#function-vec2norm">vec2Norm</a> <span class="badge">scr_utils</span></li><li><a class="inline-link" href="functions.html#function-weapontickcooldown">weaponTickCooldown</a> <span class="badge">scr_weapon</span></li><li><a class="inline-link" href="functions.html#function-weapontryfire">weaponTryFire</a> <span class="badge">scr_weapon</span></li></ul></td>
 </tr>
       </tbody>
     </table>
@@ -694,7 +658,7 @@
     </table>
 </section>
   
-    <footer>Generated on 2025-09-20T07:37:02.630Z</footer>
+    <footer>Generated on 2025-09-20T08:37:01.374Z</footer>
   </main>
 </body>
 </html>

--- a/objects/obj_bullet/Collision_obj_enemy.gml
+++ b/objects/obj_bullet/Collision_obj_enemy.gml
@@ -1,34 +1,10 @@
 /*
 * Name: obj_bullet.Collision[obj_enemy]
-* Description: Apply damage; on death spawn ammo pickups.
+* Description: Apply damage, trigger behaviour reactions, and consume the bullet.
 */
 
-// Damage
 with (other) {
-    hp -= other.damage; // 'other' here is the bullet
-    if (hp <= 0 && !is_dead) {
-        is_dead = true;
-
-        var _layer_name = layer_get_name(layer);
-
-        // Spawn stock pickup
-        var _stock_amt = irandom_range(stock_drop_min_amount, stock_drop_max_amount);
-        if (_stock_amt > 0) {
-            pickupSpawnStock(x, y, _layer_name, _stock_amt);
-        }
-
-        // Spawn modifier pickup
-        var _mod_amt = irandom_range(modifier_drop_min, modifier_drop_max);
-        if (_mod_amt > 0) {
-            var _mod_id = pickupChooseModifierId(modifier_drop_id);
-            if (_mod_id != ItemId.None) {
-                pickupSpawnModifier(x, y, _layer_name, _mod_id, _mod_amt);
-            }
-        }
-
-        instance_destroy(); // remove enemy
-    }
+    enemyApplyDamage(other.damage, other.owner);
 }
 
-// Bullet is consumed on impact
 instance_destroy();

--- a/objects/obj_bullet/Collision_obj_enemy_parent.gml
+++ b/objects/obj_bullet/Collision_obj_enemy_parent.gml
@@ -1,3 +1,6 @@
 // Apply 1 damage; if enemy dies, it will handle loot drop
-other.hp -= 1;
+with (other) {
+    enemyApplyDamage(1, other.owner);
+}
+
 instance_destroy();

--- a/objects/obj_enemy/Create_0.gml
+++ b/objects/obj_enemy/Create_0.gml
@@ -16,6 +16,9 @@ vspeed           = 0;
 speed            = 0;
 direction        = 0;
 target           = noone;
+enemy_state      = EnemyState.Idle;
+enemy_flash_timer = 0;
+enemy_stun_timer  = 0;
 
 // Loot configuration
 stock_drop_min_amount = 6;   // minimum ammo units

--- a/objects/obj_enemy/Draw_0.gml
+++ b/objects/obj_enemy/Draw_0.gml
@@ -1,0 +1,18 @@
+/*
+* Name: obj_enemy.Draw
+* Description: Draw the enemy with a brief hurt flash overlay.
+*/
+if (sprite_index != -1) {
+    draw_self();
+
+    if (enemy_flash_timer > 0) {
+        var _dur = max(1, enemy_flash_duration);
+        var _ratio = clamp(enemy_flash_timer / _dur, 0, 1);
+
+        gpu_set_blendmode(bm_add);
+        draw_sprite_ext(sprite_index, image_index, x, y, image_xscale, image_yscale, image_angle, c_white, _ratio);
+        gpu_set_blendmode(bm_normal);
+    }
+} else {
+    draw_self();
+}

--- a/objects/obj_enemy/Step_0.gml
+++ b/objects/obj_enemy/Step_0.gml
@@ -2,31 +2,19 @@ if (onPauseExit()) {
     hspeed = 0; vspeed = 0; speed = 0;
     exit;
 }
-    
+
 /*
-* Name: obj_enemy.Step (pursuit)
-* Description: Pursue the player when within range, using tilemap collision.
+* Name: obj_enemy.Step (behaviour)
+* Description: Handle timers, state transitions, and chasing logic.
 */
+if (enemy_flash_timer > 0) enemy_flash_timer -= 1;
+if (enemy_stun_timer  > 0) enemy_stun_timer  -= 1;
+
 enemySeekPlayerStep();
 
-
-if (!instance_exists(target)) {
-    target = instance_nearest(x, y, obj_player);
-}
-if (instance_exists(target)) {
-    var dx = sign(target.x - x);
-    var dy = sign(target.y - y);
-    var len = point_distance(x, y, target.x, target.y);
-    if (len > 0) {
-        dx = (target.x - x) / len;
-        dy = (target.y - y) / len;
-    }
-    x += dx * speed;
-    y += dy * speed;
-}
-
 // Die if hp <= 0 → drop ammo and slime
-if (hp <= 0) {
+if (hp <= 0 && !is_dead) {
+    is_dead = true;
 
     // Spawn ammo pickups using configured range
     var _layer_name = layer_get_name(layer);

--- a/objects/obj_enemy/obj_enemy.yy
+++ b/objects/obj_enemy/obj_enemy.yy
@@ -4,6 +4,7 @@
   "eventList":[
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_enemy",

--- a/objects/obj_enemy_1/Create_0.gml
+++ b/objects/obj_enemy_1/Create_0.gml
@@ -12,6 +12,8 @@ is_dead = false;
 */
 enemy_speed = 0.9;
 enemy_range = 160;
+enemy_activation_range = enemy_range;
+enemy_leash_range      = enemy_activation_range + 96;
 
 // Override drop configuration
 stock_drop_min_amount = 3;

--- a/objects/obj_enemy_2/Create_0.gml
+++ b/objects/obj_enemy_2/Create_0.gml
@@ -12,6 +12,8 @@ is_dead = false;
 */
 enemy_speed = 2;
 enemy_range = 200;
+enemy_activation_range = enemy_range;
+enemy_leash_range      = enemy_activation_range + 96;
 
 // Ranged attack configuration
 projectile_cooldown_max = 75; // steps between shots (configurable)


### PR DESCRIPTION
## Summary
- add an enemy state machine with shared damage handling, flash timers, and chase logic
- initialize activation/leash ranges for base and child enemies and add a hurt flash overlay with documentation updates
- route bullet collisions through the new damage entry point

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ce660e520483329b74796d1ab9e49c