### PR TITLE
Fix safe message retrieval for level triggers

### DIFF
--- a/scripts/scr_triggers/scr_triggers.gml
+++ b/scripts/scr_triggers/scr_triggers.gml
@@ -272,7 +272,8 @@ function triggerLevelSafeMessage(_property_name, _default_value)
 {
     if (variable_instance_exists(id, _property_name))
     {
-        var _text = string(self[_property_name]);
+        var _value = variable_instance_get(id, _property_name);
+        var _text = string(_value);
         if (string_length(_text) > 0)
         {
             return _text;


### PR DESCRIPTION
## Summary
- retrieve trigger level messages using `variable_instance_get` to avoid conversion errors when reading instance properties

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8e45a43483329bf6b604cb76f1fd