### PR TITLE
Fix level exit dialog callback to avoid missing room reference

### DIFF
--- a/scripts/scr_triggers/scr_triggers.gml
+++ b/scripts/scr_triggers/scr_triggers.gml
@@ -303,7 +303,19 @@ function triggerLevelHandlePlayer(_player)
     var _next_room = room_next(room);
     if (_next_room != -1)
     {
-        dialogQueuePush(_message, function() { room_goto(_next_room); });
+        dialogQueuePush(
+            _message,
+            function()
+            {
+                // Recompute the next room when the callback fires so we
+                // avoid referencing locals from the outer scope.
+                var _target_room = room_next(room);
+                if (_target_room != -1)
+                {
+                    room_goto(_target_room);
+                }
+            }
+        );
     }
     else
     {


### PR DESCRIPTION
## Summary
- rework the level exit dialog callback so it recomputes the next room when invoked instead of referencing a local variable
- ensure the callback only attempts to change rooms when a valid next room is still available

## Testing
- not run (GameMaker runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf47db5eac833290d8fa5037845434