### PR TITLE
Add interactive settings and debug menu

### DIFF
--- a/objects/obj_menu_controller/Create_0.gml
+++ b/objects/obj_menu_controller/Create_0.gml
@@ -1,8 +1,60 @@
-menu_items = [
-    "New",
-    "Continue",
-    "Load",
-    "Settings",
-    "Quit"
+menu_screen = MenuScreen.Main;
+
+menu_main = [
+    { label: "New",      kind: MenuItemKind.Action, action: "new",      enabled: true },
+    { label: "Continue", kind: MenuItemKind.Action, action: "continue", enabled: true },
+    { label: "Load",     kind: MenuItemKind.Action, action: "load",     enabled: true },
+    { label: "Settings", kind: MenuItemKind.Action, action: "settings", enabled: true },
+    { label: "Quit",     kind: MenuItemKind.Action, action: "quit",     enabled: true }
 ];
-sel = 0;
+
+menu_settings_index = 0;
+var _main_len = array_length(menu_main);
+for (var _i = 0; _i < _main_len; _i++)
+{
+    if (menu_main[_i].action == "settings")
+    {
+        menu_settings_index = _i;
+        break;
+    }
+}
+
+sel        = 0;
+menu_items = [];
+
+settings_debug_visible = false;
+
+screen_size_options = [
+    { label: "800 x 600 (1x)",   width:  800, height:  600 },
+    { label: "1200 x 900 (1.5x)", width: 1200, height:  900 },
+    { label: "1600 x 1200 (2x)",  width: 1600, height: 1200 }
+];
+
+settings_screen_index = 0;
+if (variable_global_exists("Settings"))
+{
+    settings_screen_index = clamp(global.Settings.screen_size_index, 0, max(0, array_length(screen_size_options) - 1));
+    global.Settings.screen_size_index = settings_screen_index;
+}
+
+if (is_array(screen_size_options) && array_length(screen_size_options) > 0)
+{
+    menuApplyScreenSize(screen_size_options[settings_screen_index]);
+}
+
+settings_debug_rooms = [
+    { room: rm_start, name: "Start Menu" },
+    { room: rm_game,  name: "Game" },
+    { room: rm_game_2, name: "Game 2" }
+];
+settings_load_index = 0;
+
+debug_stat_defs = [
+    { label: "Player Max HP",   stat: "hp_max",             base: "base_hp_max",        step: 1,   min: 1,   max: 50,  decimals: 0, current: "hp",   current_behaviour: "match" },
+    { label: "Player Max Ammo", stat: "ammo_max",           base: "base_ammo_max",      step: 5,   min: 0,   max: 999, decimals: 0, current: "ammo" },
+    { label: "Move Speed",      stat: "move_speed",         base: "base_move_speed",    step: 0.1, min: 0,   max: 10,  decimals: 2, suffix: " px/step" },
+    { label: "Dash Distance",   stat: "dash_distance_total", base: "base_dash_distance", step: 4,   min: 0,   max: 512, decimals: 0, suffix: " px" },
+    { label: "Bullet Damage",   stat: "bullet_damage",      base: "base_bullet_damage", step: 1,   min: 1,   max: 50,  decimals: 0 }
+];
+
+menuRebuildItems();

--- a/objects/obj_menu_controller/Draw_64.gml
+++ b/objects/obj_menu_controller/Draw_64.gml
@@ -9,16 +9,67 @@ var _H = display_get_gui_height();
 
 draw_set_halign(fa_center);
 draw_set_valign(fa_middle);
-draw_text(_W * 0.5, _H * 0.25, "PLOP");
 
-// Use the same layout as hit-testing so clicks line up exactly
-var _L = menuGetLayout();
-var _n = is_array(menu_items) ? array_length(menu_items) : 0;
+if (menu_screen == MenuScreen.Main)
+{
+    draw_set_color(c_white);
+    draw_text(_W * 0.5, _H * 0.25, "PLOP");
 
-for (var _i = 0; _i < _n; _i++) {
-    var _y     = _L.start_y + _i * _L.gap;
-    var _label = string(menu_items[_i]);
-    if (_i == sel) _label = "> " + _label + " <";
-    draw_text(_L.cx, _y, _label);
+    var _L = menuGetLayout();
+    var _n = is_array(menu_items) ? array_length(menu_items) : 0;
+
+    for (var _i = 0; _i < _n; _i++)
+    {
+        var _item  = menu_items[_i];
+        var _label = is_struct(_item) && variable_struct_exists(_item, "label") ? _item.label : string(_item);
+        if (_i == sel) _label = "> " + string(_label) + " <";
+        draw_text(_L.cx, _L.start_y + _i * _L.gap, string(_label));
+    }
 }
+else
+{
+    var _panel_x1 = _W * 0.2;
+    var _panel_y1 = _H * 0.15;
+    var _panel_x2 = _W * 0.8;
+    var _panel_y2 = _H * 0.90;
 
+    draw_set_alpha(0.75);
+    draw_set_color(make_color_rgb(20, 28, 52));
+    draw_rectangle(_panel_x1, _panel_y1, _panel_x2, _panel_y2, false);
+    draw_set_alpha(1);
+
+    draw_set_color(c_white);
+    draw_text(_W * 0.5, _H * 0.2, "Settings");
+
+    var _L = menuGetLayout();
+    var _n = is_array(menu_items) ? array_length(menu_items) : 0;
+
+    for (var _i = 0; _i < _n; _i++)
+    {
+        var _item    = menu_items[_i];
+        var _label   = is_struct(_item) && variable_struct_exists(_item, "label") ? _item.label : string(_item);
+        var _enabled = !is_struct(_item) || !variable_struct_exists(_item, "enabled") || _item.enabled;
+        var _text    = string(_label);
+        var _y       = _L.start_y + _i * _L.gap;
+
+        if (_i == sel && _enabled) _text = "> " + _text + " <";
+
+        if (!_enabled)
+        {
+            draw_set_color(make_color_rgb(140, 140, 140));
+        }
+        else if (_i == sel)
+        {
+            draw_set_color(make_color_rgb(255, 230, 120));
+        }
+        else
+        {
+            draw_set_color(c_white);
+        }
+
+        draw_text(_L.cx, _y, _text);
+    }
+
+    draw_set_color(c_white);
+    draw_text(_W * 0.5, _H * 0.88, "Use Arrow Keys / Mouse to adjust. Enter to activate.");
+}

--- a/objects/obj_menu_controller/Step_0.gml
+++ b/objects/obj_menu_controller/Step_0.gml
@@ -1,22 +1,63 @@
 /*
 * Name: obj_menu_controller.Step (mouse + keys)
-* Description: TAB toggles inventory when no menu is visible; ESC toggles pause in-game; mouse hover/click selection.
+* Description: TAB toggles inventory when no menu is visible; ESC backs out of settings/pause; keyboard & mouse drive menu.
 */
 {
-    var _in_game = (room == rm_game);
+    var _in_game = (room != rm_start);
 
-    if (!global.menuVisible && keyboard_check_pressed(vk_tab)) {
+    if (!global.menuVisible && keyboard_check_pressed(vk_tab))
+    {
         invToggle();
     }
-    if (keyboard_check_pressed(vk_escape)) {
-        if (global.invVisible) invHide();
-        else if (_in_game)      menuToggle();
+
+    if (keyboard_check_pressed(vk_escape))
+    {
+        if (global.invVisible)
+        {
+            invHide();
+        }
+        else if (global.menuVisible && menu_screen == MenuScreen.Settings)
+        {
+            menuCloseSettings();
+        }
+        else if (_in_game)
+        {
+            menuToggle();
+        }
     }
 
-    if (global.menuVisible) {
-        if (keyboard_check_pressed(vk_up))   sel = (sel - 1 + array_length(menu_items)) mod array_length(menu_items);
-        if (keyboard_check_pressed(vk_down)) sel = (sel + 1) mod array_length(menu_items);
-        if (keyboard_check_pressed(vk_enter)) menuActivateSelection();
+    if (global.menuVisible)
+    {
+        menuRebuildItems();
+
+        var _count = is_array(menu_items) ? array_length(menu_items) : 0;
+        if (_count > 0)
+        {
+            if (keyboard_check_pressed(vk_up))
+            {
+                sel = (sel - 1 + _count) mod _count;
+            }
+            if (keyboard_check_pressed(vk_down))
+            {
+                sel = (sel + 1) mod _count;
+            }
+            if (keyboard_check_pressed(vk_left))
+            {
+                menuAdjustSelection(-1);
+            }
+            if (keyboard_check_pressed(vk_right))
+            {
+                menuAdjustSelection(1);
+            }
+            if (keyboard_check_pressed(vk_enter))
+            {
+                menuActivateSelection();
+            }
+            if (keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
+            {
+                menuCloseSettings();
+            }
+        }
 
         // Mouse support
         menuMouseUpdate();

--- a/objects/obj_player/Collision_obj_enemy.gml
+++ b/objects/obj_player/Collision_obj_enemy.gml
@@ -4,6 +4,7 @@
 */
 if (damage_cd <= 0)
 {
+    if (variable_global_exists("Settings") && is_struct(global.Settings) && global.Settings.debug_god_mode) exit;
     hp -= 1;
     damage_cd = 60;    // invulnerability frames
     flash_timer = 15;  // flash white for a short time

--- a/scripts/scr_boot/scr_boot.gml
+++ b/scripts/scr_boot/scr_boot.gml
@@ -8,7 +8,25 @@ function gameInit()
         
     global.isPaused   = false; // start Paused
     global.invVisible = false; // inventory hidden by default
-    global.menuVisible = true; // Start Menu 
+    global.menuVisible = true; // Start Menu
+
+    if (!variable_global_exists("Settings"))
+    {
+        global.Settings = {
+            master_volume:    1.0,
+            screen_size_index:0,
+            debug_god_mode:   false,
+        };
+    }
+    else
+    {
+        if (!variable_struct_exists(global.Settings, "master_volume"))    global.Settings.master_volume    = 1.0;
+        if (!variable_struct_exists(global.Settings, "screen_size_index")) global.Settings.screen_size_index = 0;
+        if (!variable_struct_exists(global.Settings, "debug_god_mode"))    global.Settings.debug_god_mode   = false;
+    }
+
+    global.Settings.master_volume = clamp(global.Settings.master_volume, 0, 1);
+    audio_master_gain(audio_master, global.Settings.master_volume, 0);
     recomputePauseState(); 
         
     // Create a single global namespace for the project

--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1,16 +1,45 @@
+// ====================================================================
+// scr_menu.gml — menu layout, interaction helpers, and debug tools
+// ====================================================================
+
+enum MenuScreen
+{
+    Main     = 0,
+    Settings = 1,
+}
+
+enum MenuItemKind
+{
+    Action      = 0,
+    Slider      = 1,
+    Option      = 2,
+    Toggle      = 3,
+    DebugStat   = 4,
+    DebugAction = 5,
+    DebugLoad   = 6,
+}
+
 /*
 * Name: menuGetLayout
 * Description: Return menu layout in GUI space for hit-testing and drawing.
 */
-function menuGetLayout() {
+function menuGetLayout()
+{
     var _gui_w = display_get_gui_width();
     var _gui_h = display_get_gui_height();
+    var _mode  = MenuScreen.Main;
+    if (variable_instance_exists(id, "menu_screen")) _mode = menu_screen;
+
+    var _start_y = (_mode == MenuScreen.Settings) ? _gui_h * 0.30 : _gui_h * 0.40;
+    var _gap     = (_mode == MenuScreen.Settings) ? 26 : 28;
+    var _item_w  = (_mode == MenuScreen.Settings) ? 420 : 360;
+
     return {
         cx:       _gui_w * 0.5,
-        start_y:  _gui_h * 0.40, // MUST match Draw layout
-        gap:      28,            // MUST match Draw spacing
-        item_w:   360,           // clickable width (centered on cx)
-        item_h:   26             // clickable height
+        start_y:  _start_y, // MUST match Draw layout
+        gap:      _gap,     // MUST match Draw spacing
+        item_w:   _item_w,  // clickable width (centered on cx)
+        item_h:   26        // clickable height
     };
 }
 
@@ -18,7 +47,8 @@ function menuGetLayout() {
 * Name: menuItemBounds
 * Description: Clickable rect for item index (GUI space) → [left, top, right, bottom].
 */
-function menuItemBounds(_index) {
+function menuItemBounds(_index)
+{
     var _L      = menuGetLayout();
     var _cx     = _L.cx;
     var _base_y = _L.start_y + _index * _L.gap;
@@ -31,10 +61,12 @@ function menuItemBounds(_index) {
 * Name: menuIndexAt
 * Description: Menu index under the GUI-space point, or -1 if none.
 */
-function menuIndexAt(_mx, _my) {
+function menuIndexAt(_mx, _my)
+{
     if (!is_array(menu_items)) return -1;
     var _n = array_length(menu_items);
-    for (var _i = 0; _i < _n; _i++) {
+    for (var _i = 0; _i < _n; _i++)
+    {
         var _b = menuItemBounds(_i);
         if (_mx >= _b[0] && _mx <= _b[2] && _my >= _b[1] && _my <= _b[3]) return _i;
     }
@@ -42,51 +74,636 @@ function menuIndexAt(_mx, _my) {
 }
 
 /*
+* Name: menuRebuildItems
+* Description: Build the current menu item list (main/settings/debug overlays).
+*/
+function menuRebuildItems()
+{
+    if (!variable_instance_exists(id, "menu_screen")) return;
+
+    var _items = [];
+
+    if (!is_array(menu_main)) menu_main = [];
+
+    switch (menu_screen)
+    {
+        case MenuScreen.Main:
+        {
+            var _len = array_length(menu_main);
+            for (var _i = 0; _i < _len; _i++) _items[array_length(_items)] = menu_main[_i];
+            break;
+        }
+
+        case MenuScreen.Settings:
+        {
+            var _settings = variable_global_exists("Settings") ? global.Settings : undefined;
+            var _volume   = 1.0;
+            if (is_struct(_settings) && variable_struct_exists(_settings, "master_volume"))
+            {
+                _volume = clamp(_settings.master_volume, 0, 1);
+            }
+            var _volume_label = "Master Volume: " + string(round(_volume * 100)) + "%";
+            var _slot = array_length(_items);
+            _items[_slot] = {
+                label:   _volume_label,
+                kind:    MenuItemKind.Slider,
+                target:  "volume",
+                step:    0.1,
+                enabled: true
+            };
+
+            _slot = array_length(_items);
+            _items[_slot] = {
+                label:   menuGetScreenSizeLabel(),
+                kind:    MenuItemKind.Option,
+                target:  "screen_size",
+                enabled: is_array(screen_size_options) && array_length(screen_size_options) > 0
+            };
+
+            _slot = array_length(_items);
+            _items[_slot] = {
+                label:   settings_debug_visible ? "Hide Debug Options" : "Show Debug Options",
+                kind:    MenuItemKind.Toggle,
+                target:  "debug_panel",
+                enabled: true
+            };
+
+            if (settings_debug_visible)
+            {
+                var _player        = menuDebugGetPlayer();
+                var _player_exists = instance_exists(_player);
+
+                if (is_array(debug_stat_defs))
+                {
+                    var _count = array_length(debug_stat_defs);
+                    for (var _i = 0; _i < _count; _i++)
+                    {
+                        var _def = debug_stat_defs[_i];
+                        var _suffix = variable_struct_exists(_def, "suffix") ? _def.suffix : "";
+                        var _value_label = menuDebugDescribeStat(_player, _def);
+                        var _label = string(_def.label) + ": " + _value_label + _suffix;
+
+                        _slot = array_length(_items);
+                        _items[_slot] = {
+                            label:             _label,
+                            kind:              MenuItemKind.DebugStat,
+                            stat:              _def.stat,
+                            base:              variable_struct_exists(_def, "base") ? _def.base : undefined,
+                            step:              variable_struct_exists(_def, "step") ? _def.step : 1,
+                            min:               variable_struct_exists(_def, "min") ? _def.min : -1e9,
+                            max:               variable_struct_exists(_def, "max") ? _def.max : 1e9,
+                            decimals:          variable_struct_exists(_def, "decimals") ? _def.decimals : 0,
+                            current:           variable_struct_exists(_def, "current") ? _def.current : undefined,
+                            current_behaviour: variable_struct_exists(_def, "current_behaviour") ? _def.current_behaviour : "clamp",
+                            enabled:           _player_exists
+                        };
+                    }
+                }
+
+                _slot = array_length(_items);
+                _items[_slot] = {
+                    label:   "God Mode: " + (menuIsGodModeEnabled() ? "ON" : "OFF"),
+                    kind:    MenuItemKind.Toggle,
+                    target:  "god_mode",
+                    enabled: true
+                };
+
+                _slot = array_length(_items);
+                _items[_slot] = {
+                    label:   "Spawn Enemy",
+                    kind:    MenuItemKind.DebugAction,
+                    action:  "spawn_enemy",
+                    enabled: true
+                };
+
+                _slot = array_length(_items);
+                _items[_slot] = {
+                    label:   menuDebugGetLoadRoomLabel(),
+                    kind:    MenuItemKind.DebugLoad,
+                    enabled: is_array(settings_debug_rooms) && array_length(settings_debug_rooms) > 0
+                };
+            }
+
+            _slot = array_length(_items);
+            _items[_slot] = {
+                label:   "Back",
+                kind:    MenuItemKind.Action,
+                action:  "back",
+                enabled: true
+            };
+            break;
+        }
+    }
+
+    menu_items = _items;
+
+    var _count = array_length(menu_items);
+    if (_count <= 0) sel = 0;
+    else sel = clamp(sel, 0, _count - 1);
+}
+
+/*
 * Name: menuActivateSelection
 * Description: Perform the currently selected action (same as pressing Enter).
 */
-function menuActivateSelection() {
+function menuActivateSelection()
+{
     if (!is_array(menu_items)) return;
-    if (sel < 0 || sel >= array_length(menu_items)) return;
+    var _count = array_length(menu_items);
+    if (_count <= 0) return;
+    if (sel < 0 || sel >= _count) return;
 
-    var _choice = menu_items[sel];
+    var _entry = menu_items[sel];
+    if (!is_struct(_entry)) return;
+    if (variable_struct_exists(_entry, "enabled") && !_entry.enabled) return;
 
-    if (_choice == "New") {
-        dialogQueuePush("Welcome to the world of slime, there is too much non-slime around, you should fix that.");
-        menuHide();
-        room_goto(rm_game);
-    }
-    else if (_choice == "Continue") {
-        dialogQueuePush("Welcome back to the world of slime. You know what to do.");
-        menuHide();
-        room_goto(rm_game);
-    }
-    else if (_choice == "Load")      { 
-            // TODO  
+    switch (_entry.kind)
+    {
+        case MenuItemKind.Action:
+        {
+            var _choice = variable_struct_exists(_entry, "action") ? _entry.action : "";
+            if (_choice == "new")
+            {
+                dialogQueuePush("Welcome to the world of slime, there is too much non-slime around, you should fix that.");
+                menuHide();
+                room_goto(rm_game);
+            }
+            else if (_choice == "continue")
+            {
+                dialogQueuePush("Welcome back to the world of slime. You know what to do.");
+                menuHide();
+                room_goto(rm_game);
+            }
+            else if (_choice == "load")
+            {
+                // TODO
+            }
+            else if (_choice == "settings")
+            {
+                menuOpenSettings();
+            }
+            else if (_choice == "back")
+            {
+                menuCloseSettings();
+            }
+            else if (_choice == "quit")
+            {
+                game_end();
+            }
+            break;
         }
-    else if (_choice == "Settings")  { 
-         // TODO 
-    }
-    else if (_choice == "Quit")      { 
-        game_end(); 
-    }
-}
 
+        case MenuItemKind.Slider:
+        case MenuItemKind.Option:
+        case MenuItemKind.DebugStat:
+        {
+            menuAdjustSelection(1);
+            break;
+        }
+
+        case MenuItemKind.Toggle:
+        {
+            menuToggleEntry(_entry);
+            break;
+        }
+
+        case MenuItemKind.DebugAction:
+        {
+            var _action = variable_struct_exists(_entry, "action") ? _entry.action : "";
+            if (_action == "spawn_enemy") menuDebugSpawnEnemy();
+            break;
+        }
+
+        case MenuItemKind.DebugLoad:
+        {
+            menuDebugLoadSelectedRoom();
+            break;
+        }
+    }
+
+    if (menu_screen == MenuScreen.Settings) menuRebuildItems();
+}
 
 /*
 * Name: menuMouseUpdate
-* Description: When menu is visible, hover to select and click (LMB) to activate.
+* Description: When menu is visible, hover to select and click (LMB/RMB) to activate or adjust.
 */
-function menuMouseUpdate() {
+function menuMouseUpdate()
+{
     if (!global.menuVisible) return;
+    if (!is_array(menu_items)) return;
 
     var _mx = device_mouse_x_to_gui(0);
     var _my = device_mouse_y_to_gui(0);
 
     var _idx = menuIndexAt(_mx, _my);
     if (_idx != -1) sel = _idx;
+    else return;
 
-    if (mouse_check_button_pressed(mb_left) && _idx != -1) {
+    if (mouse_check_button_pressed(mb_left))
+    {
         menuActivateSelection();
     }
+
+    if (mouse_check_button_pressed(mb_right))
+    {
+        menuAdjustSelection(-1);
+    }
+}
+
+/*
+* Name: menuAdjustSelection
+* Description: Adjust the currently selected entry (e.g., sliders/options) by ±1 step.
+*/
+function menuAdjustSelection(_dir)
+{
+    if (_dir == 0) return;
+    if (!is_array(menu_items)) return;
+    var _count = array_length(menu_items);
+    if (_count <= 0) return;
+    if (sel < 0 || sel >= _count) return;
+
+    var _entry = menu_items[sel];
+    if (!is_struct(_entry)) return;
+    if (variable_struct_exists(_entry, "enabled") && !_entry.enabled) return;
+
+    switch (_entry.kind)
+    {
+        case MenuItemKind.Slider:
+            menuAdjustSlider(_entry, _dir);
+            break;
+
+        case MenuItemKind.Option:
+            menuAdjustOption(_entry, _dir);
+            break;
+
+        case MenuItemKind.Toggle:
+            menuToggleEntry(_entry);
+            break;
+
+        case MenuItemKind.DebugStat:
+            menuDebugAdjustStat(_entry, _dir);
+            break;
+
+        case MenuItemKind.DebugLoad:
+            menuDebugCycleRoom(_dir);
+            break;
+    }
+
+    if (menu_screen == MenuScreen.Settings) menuRebuildItems();
+}
+
+/*
+* Name: menuToggleEntry
+* Description: Toggle boolean-style entries (debug panel, god mode).
+*/
+function menuToggleEntry(_entry)
+{
+    if (!is_struct(_entry)) return;
+    var _target = variable_struct_exists(_entry, "target") ? _entry.target : "";
+
+    if (_target == "debug_panel")
+    {
+        settings_debug_visible = !settings_debug_visible;
+    }
+    else if (_target == "god_mode")
+    {
+        if (variable_global_exists("Settings"))
+        {
+            global.Settings.debug_god_mode = !global.Settings.debug_god_mode;
+        }
+    }
+
+    if (menu_screen == MenuScreen.Settings) menuRebuildItems();
+}
+
+/*
+* Name: menuAdjustSlider
+* Description: Handle slider-style adjustments (currently master volume).
+*/
+function menuAdjustSlider(_entry, _dir)
+{
+    if (_dir == 0) return;
+    if (!is_struct(_entry)) return;
+
+    var _target = variable_struct_exists(_entry, "target") ? _entry.target : "";
+
+    if (_target == "volume")
+    {
+        if (!variable_global_exists("Settings")) return;
+
+        var _step = variable_struct_exists(_entry, "step") ? max(0.01, _entry.step) : 0.1;
+        var _value = global.Settings.master_volume + _dir * _step;
+        _value = clamp(_value, 0, 1);
+        if (_step > 0)
+        {
+            _value = round(_value / _step) * _step;
+        }
+        _value = clamp(_value, 0, 1);
+
+        global.Settings.master_volume = _value;
+        audio_master_gain(audio_master, global.Settings.master_volume, 0);
+    }
+}
+
+/*
+* Name: menuAdjustOption
+* Description: Cycle through option lists (screen sizes, etc.).
+*/
+function menuAdjustOption(_entry, _dir)
+{
+    if (_dir == 0) return;
+    if (!is_struct(_entry)) return;
+
+    var _target = variable_struct_exists(_entry, "target") ? _entry.target : "";
+
+    if (_target == "screen_size")
+    {
+        if (!is_array(screen_size_options)) return;
+        var _count = array_length(screen_size_options);
+        if (_count <= 0) return;
+
+        settings_screen_index = (settings_screen_index + _dir + _count) mod _count;
+        if (variable_global_exists("Settings")) global.Settings.screen_size_index = settings_screen_index;
+
+        var _option = screen_size_options[settings_screen_index];
+        menuApplyScreenSize(_option);
+    }
+}
+
+/*
+* Name: menuOpenSettings
+* Description: Switch to the settings screen and rebuild entries.
+*/
+function menuOpenSettings()
+{
+    menu_screen = MenuScreen.Settings;
+    sel = 0;
+    menuRebuildItems();
+}
+
+/*
+* Name: menuCloseSettings
+* Description: Return to the main menu screen and rebuild entries.
+*/
+function menuCloseSettings()
+{
+    menu_screen = MenuScreen.Main;
+    var _len = is_array(menu_main) ? array_length(menu_main) : 0;
+    if (_len > 0)
+    {
+        sel = clamp(menu_settings_index, 0, _len - 1);
+    }
+    else sel = 0;
+    menuRebuildItems();
+}
+
+/*
+* Name: menuGetScreenSizeLabel
+* Description: Build the display label for the current screen size option.
+*/
+function menuGetScreenSizeLabel()
+{
+    if (!is_array(screen_size_options) || array_length(screen_size_options) <= 0)
+    {
+        return "Screen Size: (not available)";
+    }
+
+    var _count = array_length(screen_size_options);
+    settings_screen_index = clamp(settings_screen_index, 0, _count - 1);
+
+    var _option = screen_size_options[settings_screen_index];
+    var _label  = "";
+
+    if (is_struct(_option))
+    {
+        if (variable_struct_exists(_option, "label"))
+        {
+            _label = _option.label;
+        }
+        else if (variable_struct_exists(_option, "width") && variable_struct_exists(_option, "height"))
+        {
+            _label = string(_option.width) + " x " + string(_option.height);
+        }
+    }
+
+    if (_label == "") _label = "(invalid)";
+
+    return "Screen Size: " + _label;
+}
+
+/*
+* Name: menuApplyScreenSize
+* Description: Apply the supplied screen size option to the game window/gui.
+*/
+function menuApplyScreenSize(_option)
+{
+    if (!is_struct(_option)) return;
+    if (!variable_struct_exists(_option, "width")) return;
+    if (!variable_struct_exists(_option, "height")) return;
+
+    var _w = _option.width;
+    var _h = _option.height;
+
+    if (!is_real(_w) || !is_real(_h)) return;
+
+    window_set_size(_w, _h);
+
+    if (application_surface_is_enabled())
+    {
+        surface_resize(application_surface, _w, _h);
+    }
+
+    display_set_gui_size(_w, _h);
+}
+
+/*
+* Name: menuIsGodModeEnabled
+* Description: Helper to read the debug god-mode flag.
+*/
+function menuIsGodModeEnabled()
+{
+    if (!variable_global_exists("Settings")) return false;
+    if (!is_struct(global.Settings)) return false;
+    if (!variable_struct_exists(global.Settings, "debug_god_mode")) return false;
+    return global.Settings.debug_god_mode;
+}
+
+/*
+* Name: menuDebugGetPlayer
+* Description: Return the first player instance or noone if none exist.
+*/
+function menuDebugGetPlayer()
+{
+    if (instance_exists(obj_player)) return instance_find(obj_player, 0);
+    return noone;
+}
+
+/*
+* Name: menuDebugDescribeStat
+* Description: Format a player stat value for display in the debug panel.
+*/
+function menuDebugDescribeStat(_player, _def)
+{
+    if (!instance_exists(_player)) return "--";
+    if (!is_struct(_def) || !variable_struct_exists(_def, "stat")) return "--";
+
+    var _stat = _def.stat;
+    if (!variable_instance_exists(_player, _stat)) return "--";
+
+    var _value = variable_instance_get(_player, _stat);
+    var _decimals = variable_struct_exists(_def, "decimals") ? max(0, _def.decimals) : 0;
+
+    if (_decimals <= 0) return string(round(_value));
+    return string_format(_value, 0, _decimals);
+}
+
+/*
+* Name: menuDebugAdjustStat
+* Description: Adjust a numeric player stat with clamping and optional base/current synchronisation.
+*/
+function menuDebugAdjustStat(_entry, _dir)
+{
+    if (_dir == 0) return;
+    var _player = menuDebugGetPlayer();
+    if (!instance_exists(_player)) return;
+    if (!is_struct(_entry) || !variable_struct_exists(_entry, "stat")) return;
+
+    var _stat = _entry.stat;
+    if (!variable_instance_exists(_player, _stat)) return;
+
+    var _step     = variable_struct_exists(_entry, "step") ? _entry.step : 1;
+    var _min      = variable_struct_exists(_entry, "min") ? _entry.min : -1e9;
+    var _max      = variable_struct_exists(_entry, "max") ? _entry.max : 1e9;
+    var _decimals = variable_struct_exists(_entry, "decimals") ? max(0, _entry.decimals) : 0;
+
+    var _value = variable_instance_get(_player, _stat);
+    _value += _dir * _step;
+    _value = clamp(_value, _min, _max);
+
+    if (_decimals <= 0)
+    {
+        _value = round(_value);
+    }
+    else
+    {
+        var _mul = power(10, _decimals);
+        _value = round(_value * _mul) / _mul;
+    }
+
+    variable_instance_set(_player, _stat, _value);
+
+    if (variable_struct_exists(_entry, "base"))
+    {
+        var _base = _entry.base;
+        if (variable_instance_exists(_player, _base)) variable_instance_set(_player, _base, _value);
+    }
+
+    if (variable_struct_exists(_entry, "current"))
+    {
+        var _current = _entry.current;
+        if (variable_instance_exists(_player, _current))
+        {
+            if (variable_struct_exists(_entry, "current_behaviour") && _entry.current_behaviour == "match")
+            {
+                variable_instance_set(_player, _current, _value);
+            }
+            else
+            {
+                var _cur_value = variable_instance_get(_player, _current);
+                if (_cur_value > _value) variable_instance_set(_player, _current, _value);
+            }
+        }
+    }
+}
+
+/*
+* Name: menuDebugCycleRoom
+* Description: Cycle the debug room selection index.
+*/
+function menuDebugCycleRoom(_dir)
+{
+    if (_dir == 0) return;
+    if (!is_array(settings_debug_rooms)) return;
+    var _count = array_length(settings_debug_rooms);
+    if (_count <= 0) return;
+
+    settings_load_index = (settings_load_index + _dir + _count) mod _count;
+}
+
+/*
+* Name: menuDebugGetLoadRoomLabel
+* Description: Format the label for the debug load-level entry.
+*/
+function menuDebugGetLoadRoomLabel()
+{
+    if (!is_array(settings_debug_rooms) || array_length(settings_debug_rooms) <= 0)
+    {
+        return "Load Level: (no rooms)";
+    }
+
+    var _count = array_length(settings_debug_rooms);
+    settings_load_index = clamp(settings_load_index, 0, _count - 1);
+
+    var _entry = settings_debug_rooms[settings_load_index];
+    if (!is_struct(_entry) || !variable_struct_exists(_entry, "room"))
+    {
+        return "Load Level: (invalid)";
+    }
+
+    var _label = "";
+    if (variable_struct_exists(_entry, "name"))
+    {
+        _label = _entry.name;
+    }
+    else
+    {
+        var _room_name = room_get_name(_entry.room);
+        _label = string_replace_all(_room_name, "_", " ");
+    }
+
+    return "Load Level: " + _label;
+}
+
+/*
+* Name: menuDebugLoadSelectedRoom
+* Description: Jump to the currently selected debug room.
+*/
+function menuDebugLoadSelectedRoom()
+{
+    if (!is_array(settings_debug_rooms) || array_length(settings_debug_rooms) <= 0) return;
+
+    var _count = array_length(settings_debug_rooms);
+    settings_load_index = clamp(settings_load_index, 0, _count - 1);
+
+    var _entry = settings_debug_rooms[settings_load_index];
+    if (!is_struct(_entry) || !variable_struct_exists(_entry, "room")) return;
+
+    menuHide();
+    room_goto(_entry.room);
+}
+
+/*
+* Name: menuDebugSpawnEnemy
+* Description: Spawn a debug enemy near the player (or centre if no player).
+*/
+function menuDebugSpawnEnemy()
+{
+    var _player = menuDebugGetPlayer();
+
+    var _spawn_x = room_width * 0.5;
+    var _spawn_y = room_height * 0.5;
+    var _layer_id = layer_get_id("Instances");
+
+    if (instance_exists(_player))
+    {
+        _spawn_x = _player.x + 48;
+        _spawn_y = _player.y;
+        _layer_id = _player.layer;
+    }
+
+    if (_layer_id == -1) _layer_id = layer_get_id("Instances");
+    if (_layer_id == -1) _layer_id = layer_create(0, "Instances_Debug");
+
+    instance_create_layer(_spawn_x, _spawn_y, _layer_id, obj_enemy);
 }


### PR DESCRIPTION
## Summary
- add a global settings struct to persist master volume, screen size, and debug flags
- rebuild the menu script to provide a settings screen with volume/screen size controls plus a toggleable debug panel for stats, god mode, enemy spawns, and level loading
- update the menu controller draw/step/create logic to render and drive the new UI while respecting the debug god mode in player collisions

## Testing
- not run (GameMaker runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf663b00c48332bd042d837bcc83f2