### PR TITLE
Update audio master gain calls for new API

### DIFF
--- a/scripts/scr_boot/scr_boot.gml
+++ b/scripts/scr_boot/scr_boot.gml
@@ -26,7 +26,7 @@ function gameInit()
     }
 
     global.Settings.master_volume = clamp(global.Settings.master_volume, 0, 1);
-    audio_master_gain(global.Settings.master_volume, 0);
+    audio_master_gain(global.Settings.master_volume);
     recomputePauseState(); 
         
     // Create a single global namespace for the project

--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -402,7 +402,7 @@ function menuAdjustSlider(_entry, _dir)
         _value = clamp(_value, 0, 1);
 
         global.Settings.master_volume = _value;
-        audio_master_gain(audio_master, global.Settings.master_volume, 0);
+        audio_master_gain(global.Settings.master_volume);
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust the boot-time volume initialization to use the current `audio_master_gain` signature
- update the menu volume slider to apply the same single-argument call

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfe9571adc8332af08f613ad1a73b3