### PR TITLE
Handle sprite-less enemies when sizing colliders

### DIFF
--- a/scripts/scr_enemy/scr_enemy.gml
+++ b/scripts/scr_enemy/scr_enemy.gml
@@ -64,8 +64,12 @@ function enemyBaseInit() {
     enemy_stun_timer  = 0;
     enemy_state       = EnemyState.Idle;
 
-    var w = sprite_get_width(sprite_index);
-    var h = sprite_get_height(sprite_index);
+    var w = 0;
+    var h = 0;
+    if (sprite_index >= 0) {
+        w = sprite_get_width(sprite_index);
+        h = sprite_get_height(sprite_index);
+    }
     enemy_col_w = (w > 0) ? clamp(w * 0.50, 8, 24) : 16;
     enemy_col_h = (h > 0) ? clamp(h * 0.50, 8, 24) : 16;
 


### PR DESCRIPTION
## Summary
- skip sprite dimension lookup when an enemy has no assigned sprite index
- fall back to default collider dimensions so debug-spawned enemies no longer crash

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cfeb3e69348332b4808593f4f35be0