### PR TITLE
feat: allow editing debug stats via numeric input

### DIFF
--- a/objects/obj_menu_controller/Create_0.gml
+++ b/objects/obj_menu_controller/Create_0.gml
@@ -60,5 +60,8 @@ debug_stat_defs = [
 menu_dropdown_open   = -1;
 menu_dropdown_hover  = -1;
 menu_slider_drag_index = -1;
+menu_number_edit_index  = -1;
+menu_number_edit_text   = "";
+menu_number_edit_invalid = false;
 
 menuRebuildItems();

--- a/objects/obj_menu_controller/Draw_64.gml
+++ b/objects/obj_menu_controller/Draw_64.gml
@@ -161,10 +161,9 @@ else
                     var _label_left2 = _rect_num.left + 16;
                     var _rects       = menuGetNumberFieldRects(_i);
                     var _field_rect  = _rects.field;
-                    var _minus_rect  = _rects.minus;
-                    var _plus_rect   = _rects.plus;
+                    var _min_rect    = _rects.min;
+                    var _max_rect    = _rects.max;
                     var _range       = menuDebugGetStatRange(_item);
-                    var _value_text  = menuDebugGetStatDisplayValue(_item);
                     var _min_text    = menuDebugFormatStatValue(_item, _range[0]);
                     var _max_text    = menuDebugFormatStatValue(_item, _range[1]);
                     var _suffix_txt  = variable_struct_exists(_item, "suffix") ? string(_item.suffix) : "";
@@ -174,6 +173,10 @@ else
                         if (_max_text != "--") _max_text = _max_text + _suffix_txt;
                     }
 
+                    var _is_editing  = menuDebugIsEditingIndex(_i);
+                    var _value_text  = _is_editing ? string(menu_number_edit_text) : menuDebugGetStatDisplayValue(_item);
+                    if (_is_editing && _value_text == "") _value_text = "";
+
                     var _label_color2 = _enabled ? (_selected ? _color_selected : c_white) : _color_disabled;
                     draw_set_halign(fa_left);
                     draw_set_color(_label_color2);
@@ -182,17 +185,11 @@ else
                     var _field_bg     = _enabled ? make_color_rgb(36, 44, 68) : make_color_rgb(46, 46, 46);
                     var _field_border = _enabled ? make_color_rgb(120, 130, 180) : make_color_rgb(70, 70, 70);
                     if (_selected && _enabled) _field_border = _color_selected;
+                    if (_is_editing && _enabled) _field_border = make_color_rgb(150, 190, 255);
+                    if (_is_editing) _field_bg = make_color_rgb(48, 60, 96);
 
-                    var _button_bg    = _enabled ? make_color_rgb(28, 36, 60) : make_color_rgb(46, 46, 46);
-                    var _button_border = _field_border;
-
-                    draw_set_color(_button_bg);
-                    draw_rectangle(_minus_rect.left, _minus_rect.top, _minus_rect.right, _minus_rect.bottom, false);
-                    draw_rectangle(_plus_rect.left, _plus_rect.top, _plus_rect.right, _plus_rect.bottom, false);
-
-                    draw_set_color(_button_border);
-                    draw_rectangle(_minus_rect.left, _minus_rect.top, _minus_rect.right, _minus_rect.bottom, true);
-                    draw_rectangle(_plus_rect.left, _plus_rect.top, _plus_rect.right, _plus_rect.bottom, true);
+                    var _invalid = _is_editing && menu_number_edit_invalid;
+                    if (_invalid) _field_border = make_color_rgb(220, 80, 80);
 
                     draw_set_color(_field_bg);
                     draw_rectangle(_field_rect.left, _field_rect.top, _field_rect.right, _field_rect.bottom, false);
@@ -200,20 +197,18 @@ else
                     draw_rectangle(_field_rect.left, _field_rect.top, _field_rect.right, _field_rect.bottom, true);
 
                     var _value_color2 = _enabled ? (_selected ? _color_selected : c_white) : _color_disabled;
+                    if (_invalid) _value_color2 = make_color_rgb(255, 120, 120);
                     draw_set_color(_value_color2);
                     draw_set_halign(fa_center);
-                    draw_text((_minus_rect.left + _minus_rect.right) * 0.5, _minus_rect.y, "-");
-                    draw_text((_plus_rect.left + _plus_rect.right) * 0.5, _plus_rect.y, "+");
-
-                    draw_text((_field_rect.left + _field_rect.right) * 0.5, _field_rect.y - 4, _value_text);
+                    draw_set_valign(fa_middle);
+                    draw_text((_field_rect.left + _field_rect.right) * 0.5, _field_rect.y, _value_text);
 
                     var _minmax_color = _enabled ? make_color_rgb(180, 190, 230) : _color_disabled;
                     draw_set_color(_minmax_color);
-                    draw_set_valign(fa_bottom);
-                    draw_set_halign(fa_left);
-                    draw_text(_field_rect.left + 6, _field_rect.bottom - 3, "Min: " + _min_text);
                     draw_set_halign(fa_right);
-                    draw_text(_field_rect.right - 6, _field_rect.bottom - 3, "Max: " + _max_text);
+                    draw_text(_min_rect.right - 6, _field_rect.y, "Min: " + _min_text);
+                    draw_set_halign(fa_left);
+                    draw_text(_max_rect.left + 6, _field_rect.y, "Max: " + _max_text);
 
                     draw_set_valign(fa_middle);
                     draw_set_halign(fa_center);

--- a/objects/obj_menu_controller/Step_0.gml
+++ b/objects/obj_menu_controller/Step_0.gml
@@ -10,9 +10,18 @@
         invToggle();
     }
 
+    if (!global.menuVisible && menuDebugIsEditing())
+    {
+        menuDebugCancelEditing();
+    }
+
     if (keyboard_check_pressed(vk_escape))
     {
-        if (variable_instance_exists(id, "menu_dropdown_open") && menu_dropdown_open != -1)
+        if (menuDebugIsEditing())
+        {
+            menuDebugCancelEditing();
+        }
+        else if (variable_instance_exists(id, "menu_dropdown_open") && menu_dropdown_open != -1)
         {
             menuDropdownClose();
         }
@@ -34,45 +43,52 @@
     {
         menuRebuildItems();
 
+        menuDebugEnsureEditingEntryValid();
+        if (menu_screen != MenuScreen.Settings && menuDebugIsEditing()) menuDebugCancelEditing();
+
         var _dropdown_index = (variable_instance_exists(id, "menu_dropdown_open")) ? menu_dropdown_open : -1;
+
+        var _editing = menuDebugIsEditing();
+        if (_editing) menuDebugHandleEditingInput();
+        _editing = menuDebugIsEditing();
 
         if (_dropdown_index != -1)
         {
-            if (keyboard_check_pressed(vk_up)) menuDropdownStep(-1);
-            if (keyboard_check_pressed(vk_down)) menuDropdownStep(1);
-            if (keyboard_check_pressed(vk_left)) menuDropdownStep(-1);
-            if (keyboard_check_pressed(vk_right)) menuDropdownStep(1);
-            if (keyboard_check_pressed(vk_enter)) menuDropdownConfirm();
-            if (keyboard_check_pressed(vk_backspace)) menuDropdownClose();
+            if (!_editing && keyboard_check_pressed(vk_up)) menuDropdownStep(-1);
+            if (!_editing && keyboard_check_pressed(vk_down)) menuDropdownStep(1);
+            if (!_editing && keyboard_check_pressed(vk_left)) menuDropdownStep(-1);
+            if (!_editing && keyboard_check_pressed(vk_right)) menuDropdownStep(1);
+            if (!_editing && keyboard_check_pressed(vk_enter)) menuDropdownConfirm();
+            if (!_editing && keyboard_check_pressed(vk_backspace)) menuDropdownClose();
         }
         else
         {
             var _count = is_array(menu_items) ? array_length(menu_items) : 0;
             if (_count > 0)
             {
-                if (keyboard_check_pressed(vk_up))
+                if (!_editing && keyboard_check_pressed(vk_up))
                 {
                     sel = (sel - 1 + _count) mod _count;
                 }
-                if (keyboard_check_pressed(vk_down))
+                if (!_editing && keyboard_check_pressed(vk_down))
                 {
                     sel = (sel + 1) mod _count;
                 }
-                if (keyboard_check_pressed(vk_left))
+                if (!_editing && keyboard_check_pressed(vk_left))
                 {
                     menuAdjustSelection(-1);
                 }
-                if (keyboard_check_pressed(vk_right))
+                if (!_editing && keyboard_check_pressed(vk_right))
                 {
                     menuAdjustSelection(1);
                 }
-                if (keyboard_check_pressed(vk_enter))
+                if (!_editing && keyboard_check_pressed(vk_enter))
                 {
                     menuActivateSelection();
                 }
             }
 
-            if (keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
+            if (!_editing && keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
             {
                 menuCloseSettings();
             }


### PR DESCRIPTION
## Summary
- replace the debug stat plus/minus controls with a typed numeric field that validates against the stat range
- add menu editing state, keyboard handling, and validation helpers to apply the entered value and cancel cleanly
- redraw the debug stat row to highlight edits and show the min/max values alongside the input field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ed0a31088332b7718b310654906f