### PR TITLE
Add obj_floor_gen controllers to gameplay rooms

### DIFF
--- a/rooms/rm_game/rm_game.yy
+++ b/rooms/rm_game/rm_game.yy
@@ -6,6 +6,7 @@
   "inheritCreationOrder":false,
   "inheritLayers":false,
   "instanceCreationOrder":[
+    {"name":"inst_FLOOR_GEN","path":"rooms/rm_game/rm_game.yy",},
     {"name":"inst_PLAYERSPAWN","path":"rooms/rm_game/rm_game.yy",},
     {"name":"inst_7FFF7EB4","path":"rooms/rm_game/rm_game.yy",},
     {"name":"inst_13E439A6","path":"rooms/rm_game/rm_game.yy",},
@@ -14,6 +15,10 @@
   ],
   "isDnd":false,
   "layers":[
+    {"$GMRInstanceLayer":"","%Name":"Controllers","depth":-100,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[
+
+        {"$GMRInstance":"v2","%Name":"inst_FLOOR_GEN","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_FLOOR_GEN","objectId":{"name":"obj_floor_gen","path":"objects/obj_floor_gen/obj_floor_gen.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":0.0,"y":0.0,},
+      ],"layers":[],"name":"Controllers","properties":[],"resourceType":"GMRInstanceLayer","resourceVersion":"2.0","userdefinedDepth":false,"visible":true,},
     {"$GMRInstanceLayer":"","%Name":"Instances","depth":0,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[
 
         {"$GMRInstance":"v2","%Name":"inst_PLAYERSPAWN","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_PLAYERSPAWN","objectId":{"name":"obj_trigger_player_spawn","path":"objects/obj_trigger_player_spawn/obj_trigger_player_spawn.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":128.0,"y":256.0,},

--- a/rooms/rm_game_2/rm_game_2.yy
+++ b/rooms/rm_game_2/rm_game_2.yy
@@ -6,6 +6,7 @@
   "inheritCreationOrder":false,
   "inheritLayers":false,
   "instanceCreationOrder":[
+    {"name":"inst_FLOOR_GEN_1","path":"rooms/rm_game_2/rm_game_2.yy",},
     {"name":"inst_PLAYERSPAWN_1","path":"rooms/rm_game_2/rm_game_2.yy",},
     {"name":"inst_7FFF7EB4_1","path":"rooms/rm_game_2/rm_game_2.yy",},
     {"name":"inst_13E439A6_1","path":"rooms/rm_game_2/rm_game_2.yy",},
@@ -14,6 +15,10 @@
   ],
   "isDnd":false,
   "layers":[
+    {"$GMRInstanceLayer":"","%Name":"Controllers","depth":-100,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[
+
+        {"$GMRInstance":"v2","%Name":"inst_FLOOR_GEN_1","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_FLOOR_GEN_1","objectId":{"name":"obj_floor_gen","path":"objects/obj_floor_gen/obj_floor_gen.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":0.0,"y":0.0,},
+      ],"layers":[],"name":"Controllers","properties":[],"resourceType":"GMRInstanceLayer","resourceVersion":"2.0","userdefinedDepth":false,"visible":true,},
     {"$GMRInstanceLayer":"","%Name":"Instances","depth":0,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[
         {"$GMRInstance":"v2","%Name":"inst_PLAYERSPAWN_1","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_PLAYERSPAWN_1","objectId":{"name":"obj_trigger_player_spawn","path":"objects/obj_trigger_player_spawn/obj_trigger_player_spawn.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":128.0,"y":256.0,},
 


### PR DESCRIPTION
## Summary
- add a Controllers instance layer to each gameplay room and place obj_floor_gen there
- ensure the floor generator instances run before interactive objects by updating creation order

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10b844cc0833292a66ccdd16d92a7