### PR TITLE
Fix struct field assignment in layout builder

### DIFF
--- a/scripts/scr_room_generation/scr_room_generation.gml
+++ b/scripts/scr_room_generation/scr_room_generation.gml
@@ -162,8 +162,8 @@ function dgLayoutBuild(_cfg) {
                 var node_cur = ds_map_find_value(graph, cur_key);
                 var node_new = ds_map_find_value(graph, k);
 
-                node_cur[? d.side] = k;
-                node_new[? d.opp] = cur_key;
+                variable_struct_set(node_cur, d.side, k);
+                variable_struct_set(node_new, d.opp, cur_key);
 
                 ds_list_add(stack, { gx: nx, gy: ny });
                 placed = true;


### PR DESCRIPTION
## Summary
- replace ds_map accessors with variable_struct_set when linking layout nodes
- ensure floor generation builds adjacency without ds_map errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1131c87508332b390736a173ddd09