### PR TITLE
Fix runtime error when resolving tileset dimensions

### DIFF
--- a/docs/AUDIT_2025-09-22.md
+++ b/docs/AUDIT_2025-09-22.md
@@ -43,7 +43,7 @@ architecture with emphasis on:
 
 ### Built-in Functionality Usage
 - `dgLayerRequire()` now queries tile metrics via
-  `tileset_get_tilewidth/height`, adhering to manual guidance for
+  `tileset_get_tile_width/height`, adhering to manual guidance for
   tilemap creation.
 - Configuration validation uses `asset_get_index()` instead of hard-coded
   ids, improving compatibility with the IDE's asset management.

--- a/docs/documentation/functions.md
+++ b/docs/documentation/functions.md
@@ -16,7 +16,7 @@ extending the dungeon generator and related runtime systems.
 | `dgConfigDefault()` | `scripts/scr_room_generation/scr_room_generation.gml` | Returns the baseline configuration struct. Feed it into `dgConfigValidate()` before use. |
 | `dgConfigValidate(cfg)` | `scripts/scr_room_generation/scr_room_generation.gml` | Verifies numeric ranges, normalises booleans, and resolves tileset references (accepts asset ids or name strings). Emits a fatal error when misconfigured. |
 | `dgConfigEnsureTilesetId(value, field)` | `scripts/scr_room_generation/scr_room_generation.gml` | Helper used by the validator and layer bootstrapper to coerce a tileset asset id from a numeric id or asset name. |
-| `dgLayerRequire(name, tileset)` | `scripts/scr_room_generation/scr_room_generation.gml` | Ensures a tile layer exists, binding the correct tileset and tile dimensions using `tileset_get_tilewidth/height`. |
+| `dgLayerRequire(name, tileset)` | `scripts/scr_room_generation/scr_room_generation.gml` | Ensures a tile layer exists, binding the correct tileset and tile dimensions using `tileset_get_tile_width/height`. |
 | `dgLayoutBuild(cfg)` | `scripts/scr_room_generation/scr_room_generation.gml` | Builds the connected NESW room graph according to the validated config. |
 | `dgBuildFloorIntoRoom(cfg, graph, roomdb)` | `scripts/scr_room_generation/scr_room_generation.gml` | Creates tilemaps/layers via `dgLayerRequire()` and paints templates into them. |
 | `dgGenerateFloor(cfg_override)` | `scripts/scr_room_generation/scr_room_generation.gml` | Master pipeline: merges overrides, validates config, seeds RNG, builds the layout, and paints tiles. Returns the generated graph. |

--- a/scripts/scr_room_generation/scr_room_generation.gml
+++ b/scripts/scr_room_generation/scr_room_generation.gml
@@ -322,8 +322,8 @@ function dgLayerRequire(_name, _tileset) {
         layer_set_name(lid, _name);
     }
     var tid = layer_tilemap_get_id(lid);
-    var tile_w = tileset_get_tilewidth(tileset_id);
-    var tile_h = tileset_get_tileheight(tileset_id);
+    var tile_w = tileset_get_tile_width(tileset_id);
+    var tile_h = tileset_get_tile_height(tileset_id);
     if (tid == -1) {
         tid = layer_tilemap_create(lid, 0, 0, tileset_id, tile_w, tile_h);
     } else {


### PR DESCRIPTION
## Summary
- replace the dungeon generator's tileset dimension queries with the correct GameMaker API names
- update the accompanying documentation to match the revised function names

## Testing
- not run (GameMaker runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1425e5cd08332afaa8bc5be45dd23