### PR TITLE
Fix dungeon layer binding when tileset metrics are unavailable

### DIFF
--- a/docs/documentation/functions.html
+++ b/docs/documentation/functions.html
@@ -204,7 +204,7 @@
     
     <section class="card">
       <h2>Overview</h2>
-      <p>This reference covers <strong>201</strong> documented functions across <strong>16</strong> script assets.</p>
+      <p>This reference covers <strong>202</strong> documented functions across <strong>16</strong> script assets.</p>
       <nav aria-label="Function groups">
         <ul>
           <li><a href="#script-scr-boot">scr_boot <span class="badge">2</span></a></li>
@@ -219,7 +219,7 @@
 <li><a href="#script-scr-pickups">scr_pickups <span class="badge">10</span></a></li>
 <li><a href="#script-scr-player-stats">scr_player_stats <span class="badge">3</span></a></li>
 <li><a href="#script-scr-pmove">scr_pmove <span class="badge">4</span></a></li>
-<li><a href="#script-scr-room-generation">scr_room_generation <span class="badge">18</span></a></li>
+<li><a href="#script-scr-room-generation">scr_room_generation <span class="badge">19</span></a></li>
 <li><a href="#script-scr-triggers">scr_triggers <span class="badge">17</span></a></li>
 <li><a href="#script-scr-utils">scr_utils <span class="badge">15</span></a></li>
 <li><a href="#script-scr-weapon">scr_weapon <span class="badge">2</span></a></li>
@@ -1770,7 +1770,7 @@
   <p><code>function dgBuildFloorIntoRoom(_cfg, _graph, _roomdb)</code></p>
   <ul><li><code>_cfg</code></li><li><code>_graph</code></li><li><code>_roomdb</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:355</span>
+    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:413</span>
     <span title="Script asset">📄 scr_room_generation</span>
   </div>
 </article>
@@ -1820,7 +1820,7 @@
   <p><code>function dgGenerateFloor(_cfg_override)</code></p>
   <ul><li><code>_cfg_override</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:371</span>
+    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:429</span>
     <span title="Script asset">📄 scr_room_generation</span>
   </div>
 </article>
@@ -1860,7 +1860,7 @@
   <p><code>function dgLayerRequire(_name, _tileset)</code></p>
   <ul><li><code>_name</code></li><li><code>_tileset</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:317</span>
+    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:357</span>
     <span title="Script asset">📄 scr_room_generation</span>
   </div>
 </article>
@@ -1920,7 +1920,17 @@
   <p><code>function dgTilePaintRoom(_cfg, _node, _tmpl, _walk_tm, _coll_tm)</code></p>
   <ul><li><code>_cfg</code></li><li><code>_node</code></li><li><code>_tmpl</code></li><li><code>_walk_tm</code></li><li><code>_coll_tm</code></li></ul>
   <div class="meta">
-    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:338</span>
+    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:396</span>
+    <span title="Script asset">📄 scr_room_generation</span>
+  </div>
+</article>
+<article class="card" id="function-dgtilesetmetrics">
+  <h3>dgTilesetMetrics</h3>
+  <p>Resolves and caches tile dimensions for a tileset.</p>
+  <p><code>function dgTilesetMetrics(_tileset_id, _layer_name, _existing_tid)</code></p>
+  <ul><li><code>_tileset_id</code></li><li><code>_layer_name</code></li><li><code>_existing_tid</code></li></ul>
+  <div class="meta">
+    <span title="Source path">📁 scripts/scr_room_generation/scr_room_generation.gml:317</span>
     <span title="Script asset">📄 scr_room_generation</span>
   </div>
 </article>
@@ -2285,7 +2295,7 @@
 </article>
 </section>
   
-    <footer>Generated on 2025-09-22T12:23:01.734Z</footer>
+    <footer>Generated on 2025-09-22T12:56:13.121Z</footer>
   </main>
 </body>
 </html>

--- a/docs/documentation/object-script-map.html
+++ b/docs/documentation/object-script-map.html
@@ -732,7 +732,7 @@
     </table>
 </section>
   
-    <footer>Generated on 2025-09-22T12:23:01.735Z</footer>
+    <footer>Generated on 2025-09-22T12:56:13.123Z</footer>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `dgTilesetMetrics` to cache tile dimensions and reuse existing tilemaps when the runtime lacks `tileset_get_tile_width`
- update `dgLayerRequire` to request metrics only when needed and rely on the cached helper to avoid crashes
- regenerate the documentation catalogue to include the new helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14520270c83328fb026ce9544d6bb