### PR TITLE
Fix initialization of dungeon generator function cache

### DIFF
--- a/scripts/scr_room_generation/scr_room_generation.gml
+++ b/scripts/scr_room_generation/scr_room_generation.gml
@@ -39,7 +39,8 @@ function dgFunctionExists(_name) {
         return false;
     }
 
-    if (is_undefined(global.__dgFunctionExistsCache)) {
+    if (!variable_global_exists("__dgFunctionExistsCache")
+        || !is_struct(global.__dgFunctionExistsCache)) {
         global.__dgFunctionExistsCache = {};
     }
 


### PR DESCRIPTION
## Summary
- ensure the dungeon generator function cache is initialized using `variable_global_exists`
- prevent attempting to read an unset global when generating floors

## Testing
- not run (GML runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d14e6bb79c83328f9daaa066828ba2