### PR TITLE
Guard enemy archetype defaults in base enemy create event

### DIFF
--- a/objects/obj_enemy/Create_0.gml
+++ b/objects/obj_enemy/Create_0.gml
@@ -3,8 +3,11 @@
 * Description: Initialise health, archetype defaults, and essence drop configuration.
 */
 // Default archetype/tier can be overridden per instance before creation runs
-enemy_type      = EnemyType.Melee;
-enemy_toughness = EnemyToughness.Normal;
+if (!variable_instance_exists(id, "enemy_type"))
+    enemy_type = EnemyType.Melee;
+
+if (!variable_instance_exists(id, "enemy_toughness"))
+    enemy_toughness = EnemyToughness.Normal;
 
 hp_max  = ENEMY_MELEE_BASE_HP;
 hp      = hp_max;


### PR DESCRIPTION
## Summary
- guard the base enemy create event's default archetype assignments with existence checks
- ensure child enemy objects retain their overridden type and toughness before inheriting base logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5f509cf608332b35e9a71325cc4e1