### PR TITLE
Fix missing melee extra spread default for ranged enemies

### DIFF
--- a/scripts/scr_enemy_config/scr_enemy_config.gml
+++ b/scripts/scr_enemy_config/scr_enemy_config.gml
@@ -115,6 +115,7 @@ function enemyConfigBaseStats(_type)
                 melee_duration        : 0,
                 melee_distance        : 0,
                 melee_extra_attacks   : 0,
+                melee_extra_spread    : 0,
             };
 
         case EnemyType.Melee:


### PR DESCRIPTION
## Summary
- provide a default melee spread value for ranged enemy configs to prevent undefined lookups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f65f7d8c83329a1736bc79392b28