### PR TITLE
Fix melee cost lookup in player HUD

### DIFF
--- a/objects/obj_player/Draw_64.gml
+++ b/objects/obj_player/Draw_64.gml
@@ -50,7 +50,7 @@ else if (!playerEssenceCanSpend(id, ability_cost))
 }
 
 var melee_cd   = variable_instance_exists(id, "melee_cooldown") ? melee_cooldown : 0;
-var melee_cost = variable_instance_exists(id, "melee_cost") ? melee_cost : PLAYER_MELEE_ESSENCE_COST;
+var melee_cost = variable_instance_exists(id, "melee_cost") ? id.melee_cost : PLAYER_MELEE_ESSENCE_COST;
 var melee_text = "Melee (Shift): Ready (Cost " + string(melee_cost) + ")";
 
 if (melee_cd > 0)


### PR DESCRIPTION
## Summary
- resolve the melee HUD cost lookup by referencing the instance variable when available to avoid undefined local errors

## Testing
- not run (GameMaker project)


------
https://chatgpt.com/codex/tasks/task_e_68e1dc3d7ba083329465d02eca93013b