### PR TITLE
Add configurable key bindings and staged settings workflow

### DIFF
--- a/objects/obj_menu_controller/Create_0.gml
+++ b/objects/obj_menu_controller/Create_0.gml
@@ -22,6 +22,15 @@ for (var _i = 0; _i < _main_len; _i++)
 sel        = 0;
 menu_items = [];
 
+settings_pending = {};
+settings_applied = {};
+menu_settings_dirty = false;
+menu_settings_scroll = 0;
+menu_settings_scroll_max = 0;
+menu_settings_view_height = 0;
+menu_settings_content_height = 0;
+menu_keybinding_capture = undefined;
+
 settings_debug_visible = false;
 
 screen_size_options = [
@@ -31,15 +40,12 @@ screen_size_options = [
 ];
 
 settings_screen_index = 0;
-if (variable_global_exists("Settings"))
-{
-    settings_screen_index = clamp(global.Settings.screen_size_index, 0, max(0, array_length(screen_size_options) - 1));
-    global.Settings.screen_size_index = settings_screen_index;
-}
+menuSettingsLoadFromGlobal();
 
 if (is_array(screen_size_options) && array_length(screen_size_options) > 0)
 {
-    menuApplyScreenSize(screen_size_options[settings_screen_index]);
+    var _initial_index = clamp(settings_screen_index, 0, array_length(screen_size_options) - 1);
+    menuApplyScreenSize(screen_size_options[_initial_index]);
 }
 
 settings_debug_rooms = [

--- a/objects/obj_menu_controller/Step_0.gml
+++ b/objects/obj_menu_controller/Step_0.gml
@@ -5,7 +5,7 @@
 {
     var _in_game = (room != rm_start);
 
-    if (!global.menuVisible && keyboard_check_pressed(vk_tab))
+    if (!global.menuVisible && inputBindingCheckPressed("inventory"))
     {
         invToggle();
     }
@@ -17,7 +17,11 @@
 
     if (keyboard_check_pressed(vk_escape))
     {
-        if (menuDebugIsEditing())
+        if (menuKeybindingIsCapturing())
+        {
+            menuKeybindingCancelCapture();
+        }
+        else if (menuDebugIsEditing())
         {
             menuDebugCancelEditing();
         }
@@ -45,6 +49,12 @@
 
         menuDebugEnsureEditingEntryValid();
         if (menu_screen != MenuScreen.Settings && menuDebugIsEditing()) menuDebugCancelEditing();
+        if (menu_screen != MenuScreen.Settings && menuKeybindingIsCapturing()) menuKeybindingCancelCapture();
+
+        var _capturing = menuKeybindingIsCapturing();
+        if (_capturing) menuKeybindingHandleCaptureInput();
+        _capturing = menuKeybindingIsCapturing();
+        if (_capturing && menuDebugIsEditing()) menuDebugCancelEditing();
 
         var _dropdown_index = (variable_instance_exists(id, "menu_dropdown_open")) ? menu_dropdown_open : -1;
 
@@ -52,43 +62,50 @@
         if (_editing) menuDebugHandleEditingInput();
         _editing = menuDebugIsEditing();
 
+        if (menu_screen == MenuScreen.Settings && !_editing && !_capturing)
+        {
+            menuSettingsHandleKeyboardScroll();
+        }
+
         if (_dropdown_index != -1)
         {
-            if (!_editing && keyboard_check_pressed(vk_up)) menuDropdownStep(-1);
-            if (!_editing && keyboard_check_pressed(vk_down)) menuDropdownStep(1);
-            if (!_editing && keyboard_check_pressed(vk_left)) menuDropdownStep(-1);
-            if (!_editing && keyboard_check_pressed(vk_right)) menuDropdownStep(1);
-            if (!_editing && keyboard_check_pressed(vk_enter)) menuDropdownConfirm();
-            if (!_editing && keyboard_check_pressed(vk_backspace)) menuDropdownClose();
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_up)) menuDropdownStep(-1);
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_down)) menuDropdownStep(1);
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_left)) menuDropdownStep(-1);
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_right)) menuDropdownStep(1);
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_enter)) menuDropdownConfirm();
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_backspace)) menuDropdownClose();
         }
         else
         {
             var _count = is_array(menu_items) ? array_length(menu_items) : 0;
             if (_count > 0)
             {
-                if (!_editing && keyboard_check_pressed(vk_up))
+                if (!_editing && !_capturing && keyboard_check_pressed(vk_up))
                 {
                     sel = (sel - 1 + _count) mod _count;
+                    if (menu_screen == MenuScreen.Settings) menuSettingsEnsureSelectionVisible();
                 }
-                if (!_editing && keyboard_check_pressed(vk_down))
+                if (!_editing && !_capturing && keyboard_check_pressed(vk_down))
                 {
                     sel = (sel + 1) mod _count;
+                    if (menu_screen == MenuScreen.Settings) menuSettingsEnsureSelectionVisible();
                 }
-                if (!_editing && keyboard_check_pressed(vk_left))
+                if (!_editing && !_capturing && keyboard_check_pressed(vk_left))
                 {
                     menuAdjustSelection(-1);
                 }
-                if (!_editing && keyboard_check_pressed(vk_right))
+                if (!_editing && !_capturing && keyboard_check_pressed(vk_right))
                 {
                     menuAdjustSelection(1);
                 }
-                if (!_editing && keyboard_check_pressed(vk_enter))
+                if (!_editing && !_capturing && keyboard_check_pressed(vk_enter))
                 {
                     menuActivateSelection();
                 }
             }
 
-            if (!_editing && keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
             {
                 menuCloseSettings();
             }

--- a/scripts/scr_boot/scr_boot.gml
+++ b/scripts/scr_boot/scr_boot.gml
@@ -25,6 +25,15 @@ function gameInit()
         if (!variable_struct_exists(global.Settings, "debug_god_mode"))    global.Settings.debug_god_mode   = false;
     }
 
+    if (!variable_struct_exists(global.Settings, "key_bindings") || !is_struct(global.Settings.key_bindings))
+    {
+        global.Settings.key_bindings = inputCreateDefaultBindings();
+    }
+    else
+    {
+        global.Settings.key_bindings = inputBindingsEnsureDefaults(global.Settings.key_bindings);
+    }
+
     global.Settings.master_volume = clamp(global.Settings.master_volume, 0, 1);
     audio_master_gain(global.Settings.master_volume);
     recomputePauseState(); 

--- a/scripts/scr_input/scr_input.gml
+++ b/scripts/scr_input/scr_input.gml
@@ -2,17 +2,181 @@
 // scr_input.gml — keyboard mapping in one place
 // ====================================================================
 
+function inputArrayClone(_array)
+{
+    if (!is_array(_array)) return [];
+    var _len  = array_length(_array);
+    var _copy = array_create(_len);
+    for (var _i = 0; _i < _len; _i++) _copy[_i] = _array[_i];
+    return _copy;
+}
+
+function inputBindingActionDefinitions()
+{
+    static _defs = [
+        { name: "move_up",    label: "Move Up",    group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("W"), vk_up] },
+        { name: "move_down",  label: "Move Down",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("S"), vk_down] },
+        { name: "move_left",  label: "Move Left",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("A"), vk_left] },
+        { name: "move_right", label: "Move Right", group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("D"), vk_right] },
+        { name: "dash",       label: "Dash",       group: "Movement",  slots: ["Primary"],            default: [vk_space] },
+
+        { name: "melee",      label: "Melee",      group: "Combat",    slots: ["Primary"],            default: [vk_shift] },
+        { name: "ability",    label: "Ability",    group: "Combat",    slots: ["Primary"],            default: [ord("E")] },
+
+        { name: "aim_up",     label: "Aim Up",     group: "Aim",       slots: ["Primary"],            default: [ord("I")] },
+        { name: "aim_down",   label: "Aim Down",   group: "Aim",       slots: ["Primary"],            default: [ord("K")] },
+        { name: "aim_left",   label: "Aim Left",   group: "Aim",       slots: ["Primary"],            default: [ord("J")] },
+        { name: "aim_right",  label: "Aim Right",  group: "Aim",       slots: ["Primary"],            default: [ord("L")] },
+
+        { name: "inventory",  label: "Inventory",  group: "Interface", slots: ["Primary"],            default: [vk_tab] }
+    ];
+
+    return _defs;
+}
+
+function inputBindingFindDefinition(_action)
+{
+    var _defs  = inputBindingActionDefinitions();
+    var _count = array_length(_defs);
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _def = _defs[_i];
+        if (_def.name == _action) return _def;
+    }
+    return undefined;
+}
+
+function inputCreateDefaultBindings()
+{
+    var _defs    = inputBindingActionDefinitions();
+    var _count   = array_length(_defs);
+    var _result  = {};
+
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _def   = _defs[_i];
+        var _array = inputArrayClone(_def.default);
+        variable_struct_set(_result, _def.name, _array);
+    }
+
+    return _result;
+}
+
+function inputBindingsClone(_source)
+{
+    var _clone = {};
+    var _defs  = inputBindingActionDefinitions();
+    var _count = array_length(_defs);
+
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _def      = _defs[_i];
+        var _defaults = _def.default;
+        var _slots    = array_length(_defaults);
+        var _array    = array_create(_slots);
+
+        for (var _s = 0; _s < _slots; _s++)
+        {
+            var _value = undefined;
+            if (is_struct(_source) && variable_struct_exists(_source, _def.name))
+            {
+                var _src_array = variable_struct_get(_source, _def.name);
+                if (is_array(_src_array) && _s < array_length(_src_array))
+                {
+                    var _candidate = _src_array[_s];
+                    if (is_real(_candidate)) _value = _candidate;
+                }
+            }
+
+            if (!is_real(_value)) _value = _defaults[_s];
+            _array[_s] = _value;
+        }
+
+        variable_struct_set(_clone, _def.name, _array);
+    }
+
+    return _clone;
+}
+
+function inputBindingsEnsureDefaults(_bindings)
+{
+    if (!is_struct(_bindings)) _bindings = {};
+    return inputBindingsClone(_bindings);
+}
+
+function inputBindingsEqual(_lhs, _rhs)
+{
+    var _left  = inputBindingsClone(_lhs);
+    var _right = inputBindingsClone(_rhs);
+    var _defs  = inputBindingActionDefinitions();
+    var _count = array_length(_defs);
+
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _def    = _defs[_i];
+        var _left_a = variable_struct_get(_left,  _def.name);
+        var _right_a= variable_struct_get(_right, _def.name);
+        var _len    = array_length(_left_a);
+
+        for (var _j = 0; _j < _len; _j++)
+        {
+            if (_left_a[_j] != _right_a[_j]) return false;
+        }
+    }
+
+    return true;
+}
+
+function inputBindingsGetKeys(_action)
+{
+    if (!variable_global_exists("Settings")) return [];
+
+    if (!variable_struct_exists(global.Settings, "key_bindings") || !is_struct(global.Settings.key_bindings))
+    {
+        global.Settings.key_bindings = inputCreateDefaultBindings();
+    }
+
+    global.Settings.key_bindings = inputBindingsEnsureDefaults(global.Settings.key_bindings);
+
+    if (!variable_struct_exists(global.Settings.key_bindings, _action)) return [];
+
+    var _keys = variable_struct_get(global.Settings.key_bindings, _action);
+    if (!is_array(_keys)) return [];
+    return _keys;
+}
+
+function inputBindingCheckHeld(_action)
+{
+    var _keys  = inputBindingsGetKeys(_action);
+    var _count = array_length(_keys);
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _key = _keys[_i];
+        if (is_real(_key) && keyboard_check(_key)) return true;
+    }
+    return false;
+}
+
+function inputBindingCheckPressed(_action)
+{
+    var _keys  = inputBindingsGetKeys(_action);
+    var _count = array_length(_keys);
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _key = _keys[_i];
+        if (is_real(_key) && keyboard_check_pressed(_key)) return true;
+    }
+    return false;
+}
+
 /*
 * Name: inputGetMove
-* Description: Returns a normalised {dx, dy} from WASD (and arrows as backup).
+* Description: Returns a normalised {dx, dy} from the configured movement bindings.
 */
 function inputGetMove()
 {
-    var mv_dx = (keyboard_check(ord("D")) - keyboard_check(ord("A")));
-    if (mv_dx == 0) mv_dx = (keyboard_check(vk_right) - keyboard_check(vk_left));
-
-    var mv_dy = (keyboard_check(ord("S")) - keyboard_check(ord("W")));
-    if (mv_dy == 0) mv_dy = (keyboard_check(vk_down) - keyboard_check(vk_up));
+    var mv_dx = (inputBindingCheckHeld("move_right") ? 1 : 0) - (inputBindingCheckHeld("move_left")  ? 1 : 0);
+    var mv_dy = (inputBindingCheckHeld("move_down")  ? 1 : 0) - (inputBindingCheckHeld("move_up")   ? 1 : 0);
 
     var n = vec2Norm(mv_dx, mv_dy);
     return { dx: n[0], dy: n[1] };
@@ -20,43 +184,45 @@ function inputGetMove()
 
 /*
 * Name: inputGetAimHeld
-* Description: Returns a normalised {dx, dy} vector from IJKL held down.
+* Description: Returns a normalised {dx, dy} vector from configured aim bindings.
 */
 function inputGetAimHeld()
 {
-    var aim_dx = (keyboard_check(ord("L")) - keyboard_check(ord("J")));
-    var aim_dy = (keyboard_check(ord("K")) - keyboard_check(ord("I")));
+    var aim_dx = (inputBindingCheckHeld("aim_right") ? 1 : 0) - (inputBindingCheckHeld("aim_left") ? 1 : 0);
+    var aim_dy = (inputBindingCheckHeld("aim_down")  ? 1 : 0) - (inputBindingCheckHeld("aim_up")   ? 1 : 0);
     var n = vec2Norm(aim_dx, aim_dy);
     return { dx: n[0], dy: n[1] };
 }
 
 /*
 * Name: inputGetAimPressed
-* Description: Returns a unit {dx, dy} for the *pressed this step* I/J/K/L key.
-*              Priority order: I, J, K, L (up, left, down, right).
+* Description: Returns a unit {dx, dy} for the *pressed this step* aim binding.
+*              Priority order: Up, Left, Down, Right.
 */
 function inputGetAimPressed()
 {
-    if (keyboard_check_pressed(ord("I"))) return { dx:  0, dy: -1 };
-    if (keyboard_check_pressed(ord("J"))) return { dx: -1, dy:  0 };
-    if (keyboard_check_pressed(ord("K"))) return { dx:  0, dy:  1 };
-    if (keyboard_check_pressed(ord("L"))) return { dx:  1, dy:  0 };
+    if (inputBindingCheckPressed("aim_up"))    return { dx:  0, dy: -1 };
+    if (inputBindingCheckPressed("aim_left"))  return { dx: -1, dy:  0 };
+    if (inputBindingCheckPressed("aim_down"))  return { dx:  0, dy:  1 };
+    if (inputBindingCheckPressed("aim_right")) return { dx:  1, dy:  0 };
     return { dx: 0, dy: 0 };
 }
+
 /*
 * Name: inputDashPressed
-* Description: Returns true if Space is pressed this step.
+* Description: Returns true if the configured dash binding is pressed this step.
 */
 function inputDashPressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return keyboard_check_pressed(vk_space);
+    return inputBindingCheckPressed("dash");
 }
+
 /*
 * Name: inputGetAimAxis
 * Description: Returns a 2-element array [dx, dy] for current aim.
-*              Uses IJKL (held) if pressed; otherwise falls back to the instance's facing_x/facing_y.
+*              Uses configured aim bindings if pressed; otherwise falls back to the instance's facing_x/facing_y.
 */
 function inputGetAimAxis()
 {
@@ -70,11 +236,13 @@ function inputGetAimAxis()
     // Final fallback: aim right
     return [1, 0];
 }
+
 /*
 * Name: inputFirePressed
 * Description: True on the frame primary fire is pressed AND input isn't locked.
 */
-function inputFirePressed() {
+function inputFirePressed()
+{
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
     return mouse_check_button_pressed(mb_left);
@@ -84,7 +252,8 @@ function inputFirePressed() {
 * Name: inputFireHeld
 * Description: True while primary fire is held AND input isn't locked.
 */
-function inputFireHeld() {
+function inputFireHeld()
+{
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
     return mouse_check_button(mb_left);
@@ -92,22 +261,22 @@ function inputFireHeld() {
 
 /*
  * Name: inputMeleePressed
- * Description: True on the frame the melee key (Shift) is pressed while input is unlocked.
+ * Description: True on the frame the melee binding is pressed while input is unlocked.
  */
 function inputMeleePressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return keyboard_check_pressed(vk_shift);
+    return inputBindingCheckPressed("melee");
 }
 
 /*
  * Name: inputAbilityPressed
- * Description: True on the frame the ability key (E) is pressed while input is unlocked.
+ * Description: True on the frame the ability binding is pressed while input is unlocked.
  */
 function inputAbilityPressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return keyboard_check_pressed(ord("E"));
+    return inputBindingCheckPressed("ability");
 }


### PR DESCRIPTION
## Summary
- add configurable key bindings with a capture workflow that waits for the next key press and persists selections
- stage settings changes (volume, screen size, bindings) behind a highlighted Apply button and a Back action that cancels
- rebuild the settings UI so the panel fits within the viewport, scrolls overflow content, and draws the new controls

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e1de9a2b108332879b2e288ffdedfe