### PR TITLE
Handle mouse wheel delta compatibility in settings menu

### DIFF
--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1229,7 +1229,21 @@ function menuSettingsHandleMouseScroll(_mx, _my)
     if (_mx >= _view.left && _mx <= _view.right && _my >= _view.top && _my <= _view.bottom)
     {
         var _step = max(24, menuSettingsGetPageScrollAmount() * 0.25);
-        var _delta = mouse_wheel_get_delta();
+        var _delta = 0;
+
+        if (function_exists("mouse_wheel_get_delta"))
+        {
+            _delta = mouse_wheel_get_delta();
+        }
+        else if (function_exists("window_mouse_get_wheel_delta"))
+        {
+            _delta = window_mouse_get_wheel_delta();
+        }
+        else if (function_exists("device_mouse_wheel_get_delta"))
+        {
+            _delta = device_mouse_wheel_get_delta(0);
+        }
+
         if (_delta != 0)
         {
             var _direction = -sign(_delta);


### PR DESCRIPTION
## Summary
- guard the settings menu scroll handler against missing mouse wheel delta APIs
- fall back to alternate GameMaker functions when the preferred mouse wheel function is unavailable

## Testing
- not run (GameMaker project)

------
https://chatgpt.com/codex/tasks/task_e_68e1e6e7e7e0833287ff76b4b9675d4a