### PR TITLE
Fix menu keybinding cache access

### DIFF
--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1028,7 +1028,7 @@ function menuKeybindingGetKeyCode(_name)
 
     if (variable_struct_exists(_cache, _name))
     {
-        return _cache[@ _name];
+        return variable_struct_get(_cache, _name);
     }
 
     var _value = undefined;
@@ -1041,7 +1041,7 @@ function menuKeybindingGetKeyCode(_name)
         }
     }
 
-    _cache[@ _name] = _value;
+    variable_struct_set(_cache, _name, _value);
     return _value;
 }
 


### PR DESCRIPTION
## Summary
- prevent menu keybinding cache from treating key names as array indices
- use struct helpers when storing and retrieving cached key codes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ebb46ba48332b04f75619055f502