### PR TITLE
Enable settings menu scroll via mouse wheel

### DIFF
--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1323,6 +1323,23 @@ function menuSettingsHandleMouseScroll(_mx, _my)
             var _magnitude = max(1, round(abs(_delta) / 120));
             menuSettingsScrollBy(_direction * _step * _magnitude);
         }
+        else
+        {
+            var _wheel_up = mouse_check_button_pressed(mb_wheelup);
+            var _wheel_down = mouse_check_button_pressed(mb_wheeldown);
+
+            if (_wheel_up || _wheel_down)
+            {
+                var _direction = 0;
+                if (_wheel_up) _direction -= 1;
+                if (_wheel_down) _direction += 1;
+
+                if (_direction != 0)
+                {
+                    menuSettingsScrollBy(_direction * _step);
+                }
+            }
+        }
     }
 }
 

--- a/scripts/scr_room_generation/scr_room_generation.gml
+++ b/scripts/scr_room_generation/scr_room_generation.gml
@@ -68,20 +68,9 @@ function dgFunctionExists(_name) {
     }
 
     var exists = false;
-    var resolved = false;
-
-    try {
-        exists = function_exists(_name);
-        resolved = true;
-    } catch (_err) {
-        resolved = false;
-    }
-
     if (!is_undefined(override)) {
         exists = override;
-        resolved = true;
-    }
-    else if (!resolved) {
+    } else {
         var idx = asset_get_index(_name);
         if (idx != -1 && script_exists(idx)) {
             exists = true;

--- a/scripts/scr_room_generation/scr_room_generation.gml
+++ b/scripts/scr_room_generation/scr_room_generation.gml
@@ -68,9 +68,20 @@ function dgFunctionExists(_name) {
     }
 
     var exists = false;
+    var resolved = false;
+
+    try {
+        exists = function_exists(_name);
+        resolved = true;
+    } catch (_err) {
+        resolved = false;
+    }
+
     if (!is_undefined(override)) {
         exists = override;
-    } else {
+        resolved = true;
+    }
+    else if (!resolved) {
         var idx = asset_get_index(_name);
         if (idx != -1 && script_exists(idx)) {
             exists = true;


### PR DESCRIPTION
## Summary
- update `dgFunctionExists` to consult `function_exists` before falling back to asset lookups
- ensure built-in mouse wheel helpers are detected so the settings menu reacts to scroll wheel input

## Testing
- not run (not supported)


------
https://chatgpt.com/codex/tasks/task_e_68e2033ffaa48332851d83a3ff870e55