### PR TITLE
Fix settings menu mouse wheel constants

### DIFF
--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1325,8 +1325,8 @@ function menuSettingsHandleMouseScroll(_mx, _my)
         }
         else
         {
-            var _wheel_up = mouse_check_button_pressed(mb_wheelup);
-            var _wheel_down = mouse_check_button_pressed(mb_wheeldown);
+            var _wheel_up = mouse_check_button_pressed(mb_wheel_up);
+            var _wheel_down = mouse_check_button_pressed(mb_wheel_down);
 
             if (_wheel_up || _wheel_down)
             {


### PR DESCRIPTION
## Summary
- correct the mouse wheel button constants used by the settings menu scroll handler so they match GameMaker's built-in values

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68e231b2593483328c3c651fbc8b767d