### PR TITLE
Use mouse wheel helpers in settings scroll fallback

### DIFF
--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -1325,8 +1325,8 @@ function menuSettingsHandleMouseScroll(_mx, _my)
         }
         else
         {
-            var _wheel_up = mouse_check_button_pressed(mb_wheel_up);
-            var _wheel_down = mouse_check_button_pressed(mb_wheel_down);
+            var _wheel_up = mouse_wheel_up();
+            var _wheel_down = mouse_wheel_down();
 
             if (_wheel_up || _wheel_down)
             {


### PR DESCRIPTION
## Summary
- replace fallback mouse button checks in the settings scroll handler with mouse_wheel helper calls to better support legacy paths

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e38145ca188332bce5ac9c9042693e