### PR TITLE
Add keyboard/mouse and controller control schemes

### DIFF
--- a/objects/obj_menu_controller/Create_0.gml
+++ b/objects/obj_menu_controller/Create_0.gml
@@ -30,6 +30,7 @@ menu_settings_scroll_max = 0;
 menu_settings_view_height = 0;
 menu_settings_content_height = 0;
 menu_keybinding_capture = undefined;
+menu_controls_bindings_visible = false;
 
 settings_debug_visible = false;
 

--- a/objects/obj_menu_controller/Draw_64.gml
+++ b/objects/obj_menu_controller/Draw_64.gml
@@ -38,7 +38,8 @@ else
 
     draw_set_color(c_white);
     draw_set_font(fnt_menu);
-    draw_text((_panel.left + _panel.right) * 0.5, _panel.top + 32, "Settings");
+    var _title = (menu_screen == MenuScreen.SettingsControls) ? "Settings -> Controls" : "Settings";
+    draw_text((_panel.left + _panel.right) * 0.5, _panel.top + 32, _title);
     draw_set_font(fnt_ui);
 
     var _L = menuGetLayout();
@@ -57,6 +58,8 @@ else
             _dropdown_entry = undefined;
         }
     }
+
+    var _current_scheme = menuSettingsGetControlScheme();
 
     for (var _i = 0; _i < _n; _i++)
     {
@@ -184,7 +187,8 @@ else
                     var _binding = variable_struct_exists(_item, "binding") ? _item.binding : undefined;
                     var _action  = (is_struct(_binding) && variable_struct_exists(_binding, "action")) ? _binding.action : "";
                     var _slot    = (is_struct(_binding) && variable_struct_exists(_binding, "slot")) ? _binding.slot : 0;
-                    var _value_lbl = menuSettingsDescribeKeyBinding(_action, _slot);
+                    var _scheme   = (is_struct(_binding) && variable_struct_exists(_binding, "scheme")) ? _binding.scheme : menuSettingsGetControlScheme();
+                    var _value_lbl = menuSettingsDescribeKeyBinding(_action, _slot, _scheme);
                     var _is_capture = menuKeybindingIsCapturingEntry(_item);
                     if (_is_capture) _value_lbl = "Press a key...";
 
@@ -214,6 +218,34 @@ else
                     draw_set_color(_value_color);
                     draw_set_halign(fa_center);
                     draw_text((_value_rect.left + _value_rect.right) * 0.5, _value_rect.y, _value_lbl);
+                    draw_set_halign(fa_center);
+                    continue;
+                }
+
+                case MenuItemKind.Radio:
+                {
+                    var _value = variable_struct_exists(_item, "value") ? inputControlSchemeClamp(_item.value) : ControlScheme.KeyboardMouse;
+                    var _is_checked = (_value == _current_scheme);
+                    var _circle_x = _rect.left + 16;
+                    var _circle_y = _rect.y;
+                    var _radius   = 8;
+
+                    var _outline_col = _enabled ? (_selected ? _color_selected : c_white) : _color_disabled;
+                    draw_set_color(_outline_col);
+                    draw_circle(_circle_x, _circle_y, _radius, true);
+
+                    if (_is_checked)
+                    {
+                        var _fill_color = _enabled ? make_color_rgb(120, 180, 255) : make_color_rgb(80, 80, 80);
+                        draw_set_color(_fill_color);
+                        draw_circle(_circle_x, _circle_y, max(2, _radius - 3), false);
+                    }
+
+                    var _label_left = _circle_x + 16;
+                    var _text_color = _enabled ? (_selected ? _color_selected : c_white) : _color_disabled;
+                    draw_set_halign(fa_left);
+                    draw_set_color(_text_color);
+                    draw_text(_label_left, _circle_y, string(_label));
                     draw_set_halign(fa_center);
                     continue;
                 }

--- a/objects/obj_menu_controller/Step_0.gml
+++ b/objects/obj_menu_controller/Step_0.gml
@@ -37,6 +37,10 @@
         {
             menuCloseSettings();
         }
+        else if (global.menuVisible && menu_screen == MenuScreen.SettingsControls)
+        {
+            menuCloseControls();
+        }
         else if (_in_game)
         {
             menuToggle();
@@ -48,8 +52,8 @@
         menuRebuildItems();
 
         menuDebugEnsureEditingEntryValid();
-        if (menu_screen != MenuScreen.Settings && menuDebugIsEditing()) menuDebugCancelEditing();
-        if (menu_screen != MenuScreen.Settings && menuKeybindingIsCapturing()) menuKeybindingCancelCapture();
+        if (!menuIsSettingsPanel() && menuDebugIsEditing()) menuDebugCancelEditing();
+        if (!menuIsSettingsPanel() && menuKeybindingIsCapturing()) menuKeybindingCancelCapture();
 
         var _capturing = menuKeybindingIsCapturing();
         if (_capturing) menuKeybindingHandleCaptureInput();
@@ -62,7 +66,7 @@
         if (_editing) menuDebugHandleEditingInput();
         _editing = menuDebugIsEditing();
 
-        if (menu_screen == MenuScreen.Settings && !_editing && !_capturing)
+        if (menuIsSettingsPanel() && !_editing && !_capturing)
         {
             menuSettingsHandleKeyboardScroll();
         }
@@ -84,12 +88,12 @@
                 if (!_editing && !_capturing && keyboard_check_pressed(vk_up))
                 {
                     sel = (sel - 1 + _count) mod _count;
-                    if (menu_screen == MenuScreen.Settings) menuSettingsEnsureSelectionVisible();
+                    if (menuIsSettingsPanel()) menuSettingsEnsureSelectionVisible();
                 }
                 if (!_editing && !_capturing && keyboard_check_pressed(vk_down))
                 {
                     sel = (sel + 1) mod _count;
-                    if (menu_screen == MenuScreen.Settings) menuSettingsEnsureSelectionVisible();
+                    if (menuIsSettingsPanel()) menuSettingsEnsureSelectionVisible();
                 }
                 if (!_editing && !_capturing && keyboard_check_pressed(vk_left))
                 {
@@ -105,9 +109,10 @@
                 }
             }
 
-            if (!_editing && !_capturing && keyboard_check_pressed(vk_backspace) && menu_screen == MenuScreen.Settings)
+            if (!_editing && !_capturing && keyboard_check_pressed(vk_backspace))
             {
-                menuCloseSettings();
+                if (menu_screen == MenuScreen.Settings) menuCloseSettings();
+                else if (menu_screen == MenuScreen.SettingsControls) menuCloseControls();
             }
         }
 

--- a/objects/obj_player/Draw_64.gml
+++ b/objects/obj_player/Draw_64.gml
@@ -65,3 +65,22 @@ else if (!playerEssenceCanSpend(id, melee_cost))
 
 draw_text(text_x, text_y + 32, ability_text);
 draw_text(text_x, text_y + 48, melee_text);
+
+if (inputControlSchemeGet() == ControlScheme.KeyboardMouse)
+{
+    var _mx_gui = device_mouse_x_to_gui(0);
+    var _my_gui = device_mouse_y_to_gui(0);
+    var _reticle_color = make_color_rgb(255, 220, 120);
+
+    draw_set_color(_reticle_color);
+    draw_line(_mx_gui - 8, _my_gui, _mx_gui + 8, _my_gui);
+    draw_line(_mx_gui, _my_gui - 8, _mx_gui, _my_gui + 8);
+
+    draw_set_color(c_white);
+    draw_set_halign(fa_left);
+    draw_set_valign(fa_top);
+    var _mouse_text = "mouse_x: " + string_format(mouse_x, 0, 2) + "\nmouse_y: " + string_format(mouse_y, 0, 2);
+    draw_text(_mx_gui + 10, _my_gui + 10, _mouse_text);
+    draw_set_valign(fa_top);
+    draw_set_halign(fa_left);
+}

--- a/scripts/scr_boot/scr_boot.gml
+++ b/scripts/scr_boot/scr_boot.gml
@@ -16,6 +16,7 @@ function gameInit()
             master_volume:    1.0,
             screen_size_index:0,
             debug_god_mode:   false,
+            control_scheme:   ControlScheme.KeyboardMouse,
         };
     }
     else
@@ -23,6 +24,10 @@ function gameInit()
         if (!variable_struct_exists(global.Settings, "master_volume"))    global.Settings.master_volume    = 1.0;
         if (!variable_struct_exists(global.Settings, "screen_size_index")) global.Settings.screen_size_index = 0;
         if (!variable_struct_exists(global.Settings, "debug_god_mode"))    global.Settings.debug_god_mode   = false;
+        if (!variable_struct_exists(global.Settings, "control_scheme"))
+            global.Settings.control_scheme = ControlScheme.KeyboardMouse;
+        else
+            global.Settings.control_scheme = inputControlSchemeClamp(global.Settings.control_scheme);
     }
 
     if (!variable_struct_exists(global.Settings, "key_bindings") || !is_struct(global.Settings.key_bindings))

--- a/scripts/scr_input/scr_input.gml
+++ b/scripts/scr_input/scr_input.gml
@@ -1,6 +1,223 @@
 // ====================================================================
-// scr_input.gml — keyboard mapping in one place
+// scr_input.gml — keyboard/controller mapping in one place
 // ====================================================================
+
+enum ControlScheme
+{
+    KeyboardMouse = 0,
+    Controller    = 1,
+    KeyboardOnly  = 2,
+}
+
+function inputControlSchemeClamp(_scheme)
+{
+    if (!is_real(_scheme)) return ControlScheme.KeyboardMouse;
+
+    switch (_scheme)
+    {
+        case ControlScheme.Controller:
+        case ControlScheme.KeyboardOnly:
+            return _scheme;
+    }
+
+    return ControlScheme.KeyboardMouse;
+}
+
+function inputControlSchemeKey(_scheme)
+{
+    var _value = inputControlSchemeClamp(_scheme);
+
+    switch (_value)
+    {
+        case ControlScheme.Controller:   return "controller";
+        case ControlScheme.KeyboardOnly: return "keyboard_only";
+    }
+
+    return "keyboard_mouse";
+}
+
+function inputControlSchemeList()
+{
+    return [ControlScheme.KeyboardMouse, ControlScheme.Controller, ControlScheme.KeyboardOnly];
+}
+
+function inputControlSchemeGet()
+{
+    var _scheme = ControlScheme.KeyboardMouse;
+
+    if (variable_global_exists("Settings"))
+    {
+        if (!variable_struct_exists(global.Settings, "control_scheme"))
+        {
+            global.Settings.control_scheme = ControlScheme.KeyboardMouse;
+        }
+
+        _scheme = inputControlSchemeClamp(global.Settings.control_scheme);
+        global.Settings.control_scheme = _scheme;
+    }
+
+    return _scheme;
+}
+
+function inputGamepadGetActive()
+{
+    var _max = 8;
+    for (var _pad = 0; _pad < _max; _pad++)
+    {
+        if (gamepad_is_connected(_pad)) return _pad;
+    }
+    return -1;
+}
+
+function inputGamepadAllButtons()
+{
+    static _buttons = undefined;
+
+    if (!is_array(_buttons))
+    {
+        _buttons = [
+            gp_face1, gp_face2, gp_face3, gp_face4,
+            gp_shoulderl, gp_shoulderr, gp_shoulderlb, gp_shoulderrb,
+            gp_stickl, gp_stickr,
+            gp_padu, gp_paddown, gp_padleft, gp_padright,
+            gp_select, gp_start
+        ];
+    }
+
+    return _buttons;
+}
+
+function inputGamepadButtonLabel(_code)
+{
+    if (!is_real(_code)) return "(unassigned)";
+
+    switch (_code)
+    {
+        case gp_face1:      return "Face 1 (Bottom)";
+        case gp_face2:      return "Face 2 (Right)";
+        case gp_face3:      return "Face 3 (Left)";
+        case gp_face4:      return "Face 4 (Top)";
+        case gp_shoulderl:  return "Left Bumper";
+        case gp_shoulderr:  return "Right Bumper";
+        case gp_shoulderlb: return "Left Trigger";
+        case gp_shoulderrb: return "Right Trigger";
+        case gp_stickl:     return "Left Stick Button";
+        case gp_stickr:     return "Right Stick Button";
+        case gp_padu:       return "D-Pad Up";
+        case gp_paddown:    return "D-Pad Down";
+        case gp_padleft:    return "D-Pad Left";
+        case gp_padright:   return "D-Pad Right";
+        case gp_select:     return "Select";
+        case gp_start:      return "Start";
+    }
+
+    return "Button " + string(_code);
+}
+
+function inputGamepadButtonCheck(_pad, _code)
+{
+    if (_pad < 0) return false;
+    if (!is_real(_code)) return false;
+    return gamepad_button_check(_pad, _code);
+}
+
+function inputGamepadButtonCheckPressed(_pad, _code)
+{
+    if (_pad < 0) return false;
+    if (!is_real(_code)) return false;
+    return gamepad_button_check_pressed(_pad, _code);
+}
+
+function inputGamepadDigitalAxis(_pad, _positive_codes, _negative_codes)
+{
+    if (_pad < 0) return 0;
+
+    var _value = 0;
+
+    if (is_array(_positive_codes))
+    {
+        var _count_pos = array_length(_positive_codes);
+        for (var _i = 0; _i < _count_pos; _i++)
+        {
+            if (inputGamepadButtonCheck(_pad, _positive_codes[_i]))
+            {
+                _value += 1;
+                break;
+            }
+        }
+    }
+
+    if (is_array(_negative_codes))
+    {
+        var _count_neg = array_length(_negative_codes);
+        for (var _j = 0; _j < _count_neg; _j++)
+        {
+            if (inputGamepadButtonCheck(_pad, _negative_codes[_j]))
+            {
+                _value -= 1;
+                break;
+            }
+        }
+    }
+
+    return clamp(_value, -1, 1);
+}
+
+function inputBindingsSchemeEnsureStruct(_bindings, _scheme)
+{
+    if (!is_struct(_bindings)) _bindings = {};
+
+    var _key = inputControlSchemeKey(_scheme);
+    var _current = {};
+
+    if (variable_struct_exists(_bindings, _key))
+    {
+        _current = variable_struct_get(_bindings, _key);
+    }
+
+    if (!is_struct(_current)) _current = {};
+
+    var _defs  = inputBindingActionDefinitions(_scheme);
+    var _count = array_length(_defs);
+
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _def      = _defs[_i];
+        var _defaults = _def.default;
+        var _slots    = array_length(_defaults);
+        if (_slots <= 0) _slots = 1;
+
+        var _array = [];
+        if (variable_struct_exists(_current, _def.name))
+        {
+            var _existing = variable_struct_get(_current, _def.name);
+            if (is_array(_existing))
+            {
+                _array = inputArrayClone(_existing);
+            }
+        }
+
+        if (!is_array(_array) || array_length(_array) != _slots)
+        {
+            _array = inputArrayClone(_defaults);
+        }
+
+        for (var _s = 0; _s < _slots; _s++)
+        {
+            var _candidate = _array[_s];
+            if (!is_real(_candidate))
+            {
+                _array[_s] = _defaults[_s];
+            }
+        }
+
+        variable_struct_set(_current, _def.name, _array);
+    }
+
+    variable_struct_set(_bindings, _key, _current);
+    return _bindings;
+}
+
 
 function inputArrayClone(_array)
 {
@@ -11,32 +228,70 @@ function inputArrayClone(_array)
     return _copy;
 }
 
-function inputBindingActionDefinitions()
+function inputBindingActionDefinitions(_scheme)
 {
-    static _defs = [
+    _scheme = inputControlSchemeClamp(_scheme);
+
+    switch (_scheme)
+    {
+        case ControlScheme.Controller:
+        {
+            return [
+                { name: "move_up",    label: "Move Up",    group: "Movement",  slots: ["Primary"], default: [gp_padu] },
+                { name: "move_down",  label: "Move Down",  group: "Movement",  slots: ["Primary"], default: [gp_paddown] },
+                { name: "move_left",  label: "Move Left",  group: "Movement",  slots: ["Primary"], default: [gp_padleft] },
+                { name: "move_right", label: "Move Right", group: "Movement",  slots: ["Primary"], default: [gp_padright] },
+                { name: "dash",       label: "Dash",       group: "Movement",  slots: ["Primary"], default: [gp_face2] },
+
+                { name: "fire",       label: "Fire",       group: "Combat",    slots: ["Primary"], default: [gp_face1] },
+                { name: "melee",      label: "Melee",      group: "Combat",    slots: ["Primary"], default: [gp_shoulderl] },
+                { name: "ability",    label: "Ability",    group: "Combat",    slots: ["Primary"], default: [gp_shoulderr] },
+
+                { name: "inventory",  label: "Inventory",  group: "Interface", slots: ["Primary"], default: [gp_start] }
+            ];
+        }
+
+        case ControlScheme.KeyboardOnly:
+        {
+            return [
+                { name: "move_up",    label: "Move Up",    group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("W"), vk_up] },
+                { name: "move_down",  label: "Move Down",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("S"), vk_down] },
+                { name: "move_left",  label: "Move Left",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("A"), vk_left] },
+                { name: "move_right", label: "Move Right", group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("D"), vk_right] },
+                { name: "dash",       label: "Dash",       group: "Movement",  slots: ["Primary"],            default: [vk_space] },
+
+                { name: "fire",       label: "Fire",       group: "Combat",    slots: ["Primary"],            default: [vk_control] },
+                { name: "melee",      label: "Melee",      group: "Combat",    slots: ["Primary"],            default: [vk_shift] },
+                { name: "ability",    label: "Ability",    group: "Combat",    slots: ["Primary"],            default: [ord("E")] },
+
+                { name: "aim_up",     label: "Aim Up",     group: "Aim",       slots: ["Primary"],            default: [ord("I")] },
+                { name: "aim_down",   label: "Aim Down",   group: "Aim",       slots: ["Primary"],            default: [ord("K")] },
+                { name: "aim_left",   label: "Aim Left",   group: "Aim",       slots: ["Primary"],            default: [ord("J")] },
+                { name: "aim_right",  label: "Aim Right",  group: "Aim",       slots: ["Primary"],            default: [ord("L")] },
+
+                { name: "inventory",  label: "Inventory",  group: "Interface", slots: ["Primary"],            default: [vk_tab] }
+            ];
+        }
+    }
+
+    return [
         { name: "move_up",    label: "Move Up",    group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("W"), vk_up] },
         { name: "move_down",  label: "Move Down",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("S"), vk_down] },
         { name: "move_left",  label: "Move Left",  group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("A"), vk_left] },
         { name: "move_right", label: "Move Right", group: "Movement",  slots: ["Primary", "Alternate"], default: [ord("D"), vk_right] },
         { name: "dash",       label: "Dash",       group: "Movement",  slots: ["Primary"],            default: [vk_space] },
 
+        { name: "fire",       label: "Fire",       group: "Combat",    slots: ["Primary"],            default: [vk_control] },
         { name: "melee",      label: "Melee",      group: "Combat",    slots: ["Primary"],            default: [vk_shift] },
         { name: "ability",    label: "Ability",    group: "Combat",    slots: ["Primary"],            default: [ord("E")] },
 
-        { name: "aim_up",     label: "Aim Up",     group: "Aim",       slots: ["Primary"],            default: [ord("I")] },
-        { name: "aim_down",   label: "Aim Down",   group: "Aim",       slots: ["Primary"],            default: [ord("K")] },
-        { name: "aim_left",   label: "Aim Left",   group: "Aim",       slots: ["Primary"],            default: [ord("J")] },
-        { name: "aim_right",  label: "Aim Right",  group: "Aim",       slots: ["Primary"],            default: [ord("L")] },
-
         { name: "inventory",  label: "Inventory",  group: "Interface", slots: ["Primary"],            default: [vk_tab] }
     ];
-
-    return _defs;
 }
 
-function inputBindingFindDefinition(_action)
+function inputBindingFindDefinition(_action, _scheme)
 {
-    var _defs  = inputBindingActionDefinitions();
+    var _defs  = inputBindingActionDefinitions(_scheme);
     var _count = array_length(_defs);
     for (var _i = 0; _i < _count; _i++)
     {
@@ -48,15 +303,26 @@ function inputBindingFindDefinition(_action)
 
 function inputCreateDefaultBindings()
 {
-    var _defs    = inputBindingActionDefinitions();
-    var _count   = array_length(_defs);
     var _result  = {};
+    var _schemes = inputControlSchemeList();
+    var _count   = array_length(_schemes);
 
     for (var _i = 0; _i < _count; _i++)
     {
-        var _def   = _defs[_i];
-        var _array = inputArrayClone(_def.default);
-        variable_struct_set(_result, _def.name, _array);
+        var _scheme = _schemes[_i];
+        var _key    = inputControlSchemeKey(_scheme);
+        var _defs   = inputBindingActionDefinitions(_scheme);
+        var _def_count = array_length(_defs);
+        var _map    = {};
+
+        for (var _d = 0; _d < _def_count; _d++)
+        {
+            var _def   = _defs[_d];
+            var _array = inputArrayClone(_def.default);
+            variable_struct_set(_map, _def.name, _array);
+        }
+
+        variable_struct_set(_result, _key, _map);
     }
 
     return _result;
@@ -64,35 +330,52 @@ function inputCreateDefaultBindings()
 
 function inputBindingsClone(_source)
 {
-    var _clone = {};
-    var _defs  = inputBindingActionDefinitions();
-    var _count = array_length(_defs);
+    var _clone   = {};
+    var _schemes = inputControlSchemeList();
+    var _count   = array_length(_schemes);
 
     for (var _i = 0; _i < _count; _i++)
     {
-        var _def      = _defs[_i];
-        var _defaults = _def.default;
-        var _slots    = array_length(_defaults);
-        var _array    = array_create(_slots);
+        var _scheme = _schemes[_i];
+        var _key    = inputControlSchemeKey(_scheme);
+        var _defs   = inputBindingActionDefinitions(_scheme);
+        var _map    = {};
+        var _def_count = array_length(_defs);
 
-        for (var _s = 0; _s < _slots; _s++)
+        var _source_map = {};
+        if (is_struct(_source) && variable_struct_exists(_source, _key))
         {
-            var _value = undefined;
-            if (is_struct(_source) && variable_struct_exists(_source, _def.name))
-            {
-                var _src_array = variable_struct_get(_source, _def.name);
-                if (is_array(_src_array) && _s < array_length(_src_array))
-                {
-                    var _candidate = _src_array[_s];
-                    if (is_real(_candidate)) _value = _candidate;
-                }
-            }
-
-            if (!is_real(_value)) _value = _defaults[_s];
-            _array[_s] = _value;
+            _source_map = variable_struct_get(_source, _key);
         }
 
-        variable_struct_set(_clone, _def.name, _array);
+        for (var _d = 0; _d < _def_count; _d++)
+        {
+            var _def      = _defs[_d];
+            var _defaults = _def.default;
+            var _slots    = array_length(_defaults);
+            var _array    = array_create(_slots);
+
+            for (var _s = 0; _s < _slots; _s++)
+            {
+                var _value = undefined;
+                if (is_struct(_source_map) && variable_struct_exists(_source_map, _def.name))
+                {
+                    var _src_array = variable_struct_get(_source_map, _def.name);
+                    if (is_array(_src_array) && _s < array_length(_src_array))
+                    {
+                        var _candidate = _src_array[_s];
+                        if (is_real(_candidate)) _value = _candidate;
+                    }
+                }
+
+                if (!is_real(_value)) _value = _defaults[_s];
+                _array[_s] = _value;
+            }
+
+            variable_struct_set(_map, _def.name, _array);
+        }
+
+        variable_struct_set(_clone, _key, _map);
     }
 
     return _clone;
@@ -101,34 +384,58 @@ function inputBindingsClone(_source)
 function inputBindingsEnsureDefaults(_bindings)
 {
     if (!is_struct(_bindings)) _bindings = {};
-    return inputBindingsClone(_bindings);
+
+    var _schemes = inputControlSchemeList();
+    var _count   = array_length(_schemes);
+
+    for (var _i = 0; _i < _count; _i++)
+    {
+        var _scheme = _schemes[_i];
+        _bindings = inputBindingsSchemeEnsureStruct(_bindings, _scheme);
+    }
+
+    return _bindings;
 }
 
 function inputBindingsEqual(_lhs, _rhs)
 {
-    var _left  = inputBindingsClone(_lhs);
-    var _right = inputBindingsClone(_rhs);
-    var _defs  = inputBindingActionDefinitions();
-    var _count = array_length(_defs);
+    var _left    = inputBindingsClone(_lhs);
+    var _right   = inputBindingsClone(_rhs);
+    var _schemes = inputControlSchemeList();
+    var _count   = array_length(_schemes);
 
     for (var _i = 0; _i < _count; _i++)
     {
-        var _def    = _defs[_i];
-        var _left_a = variable_struct_get(_left,  _def.name);
-        var _right_a= variable_struct_get(_right, _def.name);
-        var _len    = array_length(_left_a);
+        var _scheme = _schemes[_i];
+        var _key    = inputControlSchemeKey(_scheme);
 
-        for (var _j = 0; _j < _len; _j++)
+        var _left_map  = variable_struct_get(_left,  _key);
+        var _right_map = variable_struct_get(_right, _key);
+
+        var _defs = inputBindingActionDefinitions(_scheme);
+        var _def_count = array_length(_defs);
+
+        for (var _d = 0; _d < _def_count; _d++)
         {
-            if (_left_a[_j] != _right_a[_j]) return false;
+            var _def    = _defs[_d];
+            var _left_a = variable_struct_get(_left_map,  _def.name);
+            var _right_a= variable_struct_get(_right_map, _def.name);
+            var _len    = array_length(_left_a);
+
+            for (var _j = 0; _j < _len; _j++)
+            {
+                if (_left_a[_j] != _right_a[_j]) return false;
+            }
         }
     }
 
     return true;
 }
 
-function inputBindingsGetKeys(_action)
+function inputBindingsGetKeys(_action, _scheme)
 {
+    if (!is_real(_scheme)) _scheme = inputControlSchemeGet();
+
     if (!variable_global_exists("Settings")) return [];
 
     if (!variable_struct_exists(global.Settings, "key_bindings") || !is_struct(global.Settings.key_bindings))
@@ -138,33 +445,61 @@ function inputBindingsGetKeys(_action)
 
     global.Settings.key_bindings = inputBindingsEnsureDefaults(global.Settings.key_bindings);
 
-    if (!variable_struct_exists(global.Settings.key_bindings, _action)) return [];
+    var _key = inputControlSchemeKey(_scheme);
+    if (!variable_struct_exists(global.Settings.key_bindings, _key)) return [];
 
-    var _keys = variable_struct_get(global.Settings.key_bindings, _action);
+    var _map = variable_struct_get(global.Settings.key_bindings, _key);
+    if (!is_struct(_map)) return [];
+
+    if (!variable_struct_exists(_map, _action)) return [];
+
+    var _keys = variable_struct_get(_map, _action);
     if (!is_array(_keys)) return [];
     return _keys;
 }
 
-function inputBindingCheckHeld(_action)
+function inputBindingCheckHeld(_action, _scheme)
 {
-    var _keys  = inputBindingsGetKeys(_action);
+    if (!is_real(_scheme)) _scheme = inputControlSchemeGet();
+    var _keys  = inputBindingsGetKeys(_action, _scheme);
     var _count = array_length(_keys);
     for (var _i = 0; _i < _count; _i++)
     {
         var _key = _keys[_i];
-        if (is_real(_key) && keyboard_check(_key)) return true;
+        if (!is_real(_key)) continue;
+
+        if (_scheme == ControlScheme.Controller)
+        {
+            var _pad = inputGamepadGetActive();
+            if (inputGamepadButtonCheck(_pad, _key)) return true;
+        }
+        else
+        {
+            if (keyboard_check(_key)) return true;
+        }
     }
     return false;
 }
 
-function inputBindingCheckPressed(_action)
+function inputBindingCheckPressed(_action, _scheme)
 {
-    var _keys  = inputBindingsGetKeys(_action);
+    if (!is_real(_scheme)) _scheme = inputControlSchemeGet();
+    var _keys  = inputBindingsGetKeys(_action, _scheme);
     var _count = array_length(_keys);
     for (var _i = 0; _i < _count; _i++)
     {
         var _key = _keys[_i];
-        if (is_real(_key) && keyboard_check_pressed(_key)) return true;
+        if (!is_real(_key)) continue;
+
+        if (_scheme == ControlScheme.Controller)
+        {
+            var _pad = inputGamepadGetActive();
+            if (inputGamepadButtonCheckPressed(_pad, _key)) return true;
+        }
+        else
+        {
+            if (keyboard_check_pressed(_key)) return true;
+        }
     }
     return false;
 }
@@ -175,8 +510,46 @@ function inputBindingCheckPressed(_action)
 */
 function inputGetMove()
 {
-    var mv_dx = (inputBindingCheckHeld("move_right") ? 1 : 0) - (inputBindingCheckHeld("move_left")  ? 1 : 0);
-    var mv_dy = (inputBindingCheckHeld("move_down")  ? 1 : 0) - (inputBindingCheckHeld("move_up")   ? 1 : 0);
+    var _scheme = inputControlSchemeGet();
+
+    if (_scheme == ControlScheme.Controller)
+    {
+        var _pad = inputGamepadGetActive();
+        var _dx  = 0;
+        var _dy  = 0;
+
+        if (_pad != -1)
+        {
+            var _analog_x = gamepad_axis_value(_pad, gp_axislh);
+            var _analog_y = gamepad_axis_value(_pad, gp_axislv);
+            var _analog_len_sq = _analog_x * _analog_x + _analog_y * _analog_y;
+            var _deadzone = 0.25;
+
+            if (_analog_len_sq >= _deadzone * _deadzone)
+            {
+                _dx = _analog_x;
+                _dy = _analog_y;
+            }
+
+            var _digital_dx = inputGamepadDigitalAxis(_pad, inputBindingsGetKeys("move_right", ControlScheme.Controller), inputBindingsGetKeys("move_left", ControlScheme.Controller));
+            var _digital_dy = inputGamepadDigitalAxis(_pad, inputBindingsGetKeys("move_down",  ControlScheme.Controller), inputBindingsGetKeys("move_up",   ControlScheme.Controller));
+
+            _dx += _digital_dx;
+            _dy += _digital_dy;
+        }
+
+        if (_dx != 0 || _dy != 0)
+        {
+            var _norm_ctrl = vec2Norm(_dx, _dy);
+            return { dx: _norm_ctrl[0], dy: _norm_ctrl[1] };
+        }
+
+        // Fallback: allow keyboard movement if controller is idle or absent
+        _scheme = ControlScheme.KeyboardOnly;
+    }
+
+    var mv_dx = (inputBindingCheckHeld("move_right", _scheme) ? 1 : 0) - (inputBindingCheckHeld("move_left",  _scheme) ? 1 : 0);
+    var mv_dy = (inputBindingCheckHeld("move_down",  _scheme) ? 1 : 0) - (inputBindingCheckHeld("move_up",    _scheme) ? 1 : 0);
 
     var n = vec2Norm(mv_dx, mv_dy);
     return { dx: n[0], dy: n[1] };
@@ -188,8 +561,57 @@ function inputGetMove()
 */
 function inputGetAimHeld()
 {
-    var aim_dx = (inputBindingCheckHeld("aim_right") ? 1 : 0) - (inputBindingCheckHeld("aim_left") ? 1 : 0);
-    var aim_dy = (inputBindingCheckHeld("aim_down")  ? 1 : 0) - (inputBindingCheckHeld("aim_up")   ? 1 : 0);
+    var _scheme = inputControlSchemeGet();
+
+    if (_scheme == ControlScheme.KeyboardMouse)
+    {
+        var _mx = device_mouse_x(0);
+        var _my = device_mouse_y(0);
+        var _dx = _mx - x;
+        var _dy = _my - y;
+        var _norm_mouse = vec2Norm(_dx, _dy);
+        return { dx: _norm_mouse[0], dy: _norm_mouse[1] };
+    }
+
+    if (_scheme == ControlScheme.Controller)
+    {
+        var _pad = inputGamepadGetActive();
+        var _dx  = 0;
+        var _dy  = 0;
+
+        if (_pad != -1)
+        {
+            var _analog_x = gamepad_axis_value(_pad, gp_axisrh);
+            var _analog_y = gamepad_axis_value(_pad, gp_axisrv);
+            var _analog_len_sq = _analog_x * _analog_x + _analog_y * _analog_y;
+            var _deadzone = 0.25;
+
+            if (_analog_len_sq >= _deadzone * _deadzone)
+            {
+                _dx = _analog_x;
+                _dy = _analog_y;
+            }
+            else
+            {
+                var _digital_dx = inputGamepadDigitalAxis(_pad, inputBindingsGetKeys("aim_right", ControlScheme.Controller), inputBindingsGetKeys("aim_left", ControlScheme.Controller));
+                var _digital_dy = inputGamepadDigitalAxis(_pad, inputBindingsGetKeys("aim_down",  ControlScheme.Controller), inputBindingsGetKeys("aim_up",   ControlScheme.Controller));
+                _dx = _digital_dx;
+                _dy = _digital_dy;
+            }
+        }
+
+        if (_dx != 0 || _dy != 0)
+        {
+            var _norm_ctrl = vec2Norm(_dx, _dy);
+            return { dx: _norm_ctrl[0], dy: _norm_ctrl[1] };
+        }
+
+        // Allow keyboard fallback when the stick is neutral
+        _scheme = ControlScheme.KeyboardOnly;
+    }
+
+    var aim_dx = (inputBindingCheckHeld("aim_right", _scheme) ? 1 : 0) - (inputBindingCheckHeld("aim_left", _scheme) ? 1 : 0);
+    var aim_dy = (inputBindingCheckHeld("aim_down",  _scheme) ? 1 : 0) - (inputBindingCheckHeld("aim_up",   _scheme) ? 1 : 0);
     var n = vec2Norm(aim_dx, aim_dy);
     return { dx: n[0], dy: n[1] };
 }
@@ -201,10 +623,27 @@ function inputGetAimHeld()
 */
 function inputGetAimPressed()
 {
-    if (inputBindingCheckPressed("aim_up"))    return { dx:  0, dy: -1 };
-    if (inputBindingCheckPressed("aim_left"))  return { dx: -1, dy:  0 };
-    if (inputBindingCheckPressed("aim_down"))  return { dx:  0, dy:  1 };
-    if (inputBindingCheckPressed("aim_right")) return { dx:  1, dy:  0 };
+    var _scheme = inputControlSchemeGet();
+
+    if (_scheme == ControlScheme.KeyboardMouse)
+    {
+        return { dx: 0, dy: 0 };
+    }
+
+    if (_scheme == ControlScheme.Controller)
+    {
+        if (inputBindingCheckPressed("aim_up", ControlScheme.Controller))    return { dx:  0, dy: -1 };
+        if (inputBindingCheckPressed("aim_left", ControlScheme.Controller))  return { dx: -1, dy:  0 };
+        if (inputBindingCheckPressed("aim_down", ControlScheme.Controller))  return { dx:  0, dy:  1 };
+        if (inputBindingCheckPressed("aim_right", ControlScheme.Controller)) return { dx:  1, dy:  0 };
+
+        _scheme = ControlScheme.KeyboardOnly;
+    }
+
+    if (inputBindingCheckPressed("aim_up", _scheme))    return { dx:  0, dy: -1 };
+    if (inputBindingCheckPressed("aim_left", _scheme))  return { dx: -1, dy:  0 };
+    if (inputBindingCheckPressed("aim_down", _scheme))  return { dx:  0, dy:  1 };
+    if (inputBindingCheckPressed("aim_right", _scheme)) return { dx:  1, dy:  0 };
     return { dx: 0, dy: 0 };
 }
 
@@ -216,7 +655,10 @@ function inputDashPressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return inputBindingCheckPressed("dash");
+    var _scheme = inputControlSchemeGet();
+    if (inputBindingCheckPressed("dash", _scheme)) return true;
+    if (_scheme == ControlScheme.Controller) return inputBindingCheckPressed("dash", ControlScheme.KeyboardOnly);
+    return false;
 }
 
 /*
@@ -245,7 +687,22 @@ function inputFirePressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return mouse_check_button_pressed(mb_left);
+    var _scheme = inputControlSchemeGet();
+
+    if (_scheme == ControlScheme.KeyboardMouse)
+    {
+        if (mouse_check_button_pressed(mb_left)) return true;
+        return inputBindingCheckPressed("fire", ControlScheme.KeyboardMouse);
+    }
+
+    if (_scheme == ControlScheme.Controller)
+    {
+        if (inputBindingCheckPressed("fire", ControlScheme.Controller)) return true;
+        return inputBindingCheckPressed("fire", ControlScheme.KeyboardOnly);
+    }
+
+    if (mouse_check_button_pressed(mb_left)) return true;
+    return inputBindingCheckPressed("fire", ControlScheme.KeyboardOnly);
 }
 
 /*
@@ -256,7 +713,22 @@ function inputFireHeld()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return mouse_check_button(mb_left);
+    var _scheme = inputControlSchemeGet();
+
+    if (_scheme == ControlScheme.KeyboardMouse)
+    {
+        if (mouse_check_button(mb_left)) return true;
+        return inputBindingCheckHeld("fire", ControlScheme.KeyboardMouse);
+    }
+
+    if (_scheme == ControlScheme.Controller)
+    {
+        if (inputBindingCheckHeld("fire", ControlScheme.Controller)) return true;
+        return inputBindingCheckHeld("fire", ControlScheme.KeyboardOnly);
+    }
+
+    if (mouse_check_button(mb_left)) return true;
+    return inputBindingCheckHeld("fire", ControlScheme.KeyboardOnly);
 }
 
 /*
@@ -267,7 +739,10 @@ function inputMeleePressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return inputBindingCheckPressed("melee");
+    var _scheme = inputControlSchemeGet();
+    if (inputBindingCheckPressed("melee", _scheme)) return true;
+    if (_scheme == ControlScheme.Controller) return inputBindingCheckPressed("melee", ControlScheme.KeyboardOnly);
+    return false;
 }
 
 /*
@@ -278,5 +753,8 @@ function inputAbilityPressed()
 {
     var _locked = variable_instance_exists(id, "input_locked") && input_locked;
     if (_locked) return false;
-    return inputBindingCheckPressed("ability");
+    var _scheme = inputControlSchemeGet();
+    if (inputBindingCheckPressed("ability", _scheme)) return true;
+    if (_scheme == ControlScheme.Controller) return inputBindingCheckPressed("ability", ControlScheme.KeyboardOnly);
+    return false;
 }


### PR DESCRIPTION
## Summary
- add control scheme infrastructure with controller helpers, per-scheme binding maps, and aim handling for keyboard, mouse, and controller
- expose the control scheme selection and per-scheme bindings in a new Settings -> Controls menu
- render a GUI reticle for mouse aiming and move key binding controls into the new menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38821f1c08332896d815cf841d77a