### PR TITLE
Fix control scheme radio buttons not updating

### DIFF
--- a/objects/obj_menu_controller/Create_0.gml
+++ b/objects/obj_menu_controller/Create_0.gml
@@ -41,6 +41,7 @@ screen_size_options = [
 ];
 
 settings_screen_index = 0;
+settings_control_scheme = ControlScheme.KeyboardMouse;
 menuSettingsLoadFromGlobal();
 
 if (is_array(screen_size_options) && array_length(screen_size_options) > 0)


### PR DESCRIPTION
## Summary
- track the pending control scheme selection on the menu controller instance
- keep the control scheme in sync across load, apply, revert, and dirty state helpers so radio buttons reflect the current choice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e632ee9c8c8332a1dde5cf3fdc38d3