### PR TITLE
Fix control scheme radio and enemy contact collisions

### DIFF
--- a/objects/obj_player/Collision_obj_enemy.gml
+++ b/objects/obj_player/Collision_obj_enemy.gml
@@ -1,11 +1,5 @@
 /*
 * Name: obj_player.Collision[obj_enemy]
-* Description: Apply damage with cooldown when touching enemies.
+* Description: Collision damage is disabled; physical separation handled in movement helpers.
 */
-if (damage_cd <= 0)
-{
-    if (variable_global_exists("Settings") && is_struct(global.Settings) && global.Settings.debug_god_mode) exit;
-    playerEssenceSpend(id, ENEMY_CONTACT_ESSENCE_DAMAGE);
-    damage_cd = 60;    // invulnerability frames
-    flash_timer = 15;  // flash white for a short time
-}
+// Intentionally empty — contact with enemies should no longer deal damage.

--- a/scripts/scr_enemy/scr_enemy.gml
+++ b/scripts/scr_enemy/scr_enemy.gml
@@ -626,7 +626,7 @@ function tmRectHitsSolid(_tm, _x, _y, _w, _h)
 /*
 * Name: moveAxisWithTilemap
 * Description: Axis-separated movement with tilemap collision that supports fractional speeds
-*              via per-instance accumulators (enemy_move_rx / enemy_move_ry). No overshoot.
+*              via per-instance accumulators (enemy_move_rx / enemy_move_ry) and blocks the player.
 */
 function moveAxisWithTilemap(_tm, _axis, _amount, _w, _h)
 {
@@ -641,16 +641,27 @@ function moveAxisWithTilemap(_tm, _axis, _amount, _w, _h)
     var _steps = floor(abs(_total));
     var _moved = 0;
     var _hit   = false;
+    var _block_player = object_exists(obj_player);
 
     // Step pixel-by-pixel; stop if we hit a solid
     for (var _i = 0; _i < _steps; _i++)
     {
+        var _prev_x = x;
+        var _prev_y = y;
         if (_axis == 0) x += _dir; else y += _dir;
 
-        if (tmRectHitsSolid(_tm, x, y, _w, _h))
+        var _blocked = tmRectHitsSolid(_tm, x, y, _w, _h);
+        if (!_blocked && _block_player)
+        {
+            var _player_hit = instance_place(x, y, obj_player);
+            _blocked = (_player_hit != noone);
+        }
+
+        if (_blocked)
         {
             // undo the last step; we are blocked
-            if (_axis == 0) x -= _dir; else y -= _dir;
+            x = _prev_x;
+            y = _prev_y;
             _hit = true;
             break;
         }

--- a/scripts/scr_menu/scr_menu.gml
+++ b/scripts/scr_menu/scr_menu.gml
@@ -764,19 +764,22 @@ function menuSettingsGetControlScheme()
 
     var _scheme = ControlScheme.KeyboardMouse;
 
-    if (variable_instance_exists(id, "settings_control_scheme"))
-    {
-        _scheme = settings_control_scheme;
-    }
-
     if (variable_struct_exists(settings_pending, "control_scheme"))
     {
         _scheme = settings_pending.control_scheme;
     }
+    else if (variable_instance_exists(id, "settings_control_scheme"))
+    {
+        _scheme = settings_control_scheme;
+    }
+    else if (variable_global_exists("Settings") && variable_struct_exists(global.Settings, "control_scheme"))
+    {
+        _scheme = global.Settings.control_scheme;
+    }
 
     _scheme = inputControlSchemeClamp(_scheme);
-    settings_control_scheme = _scheme;
     settings_pending.control_scheme = _scheme;
+    settings_control_scheme = _scheme;
     return _scheme;
 }
 

--- a/scripts/scr_pmove/scr_pmove.gml
+++ b/scripts/scr_pmove/scr_pmove.gml
@@ -34,32 +34,64 @@ function pmovePlaceMeetingTilemap(inst, tilemap_id, test_x, test_y, inset)
 
 /*
 * Name: pmoveMoveAxis
-* Description: Moves instance along one axis with pixel sweep to avoid tunnelling on tiles.
+* Description: Moves instance along one axis with pixel sweep to avoid tunnelling on tiles and enemies.
 */
 function pmoveMoveAxis(inst, tilemap_id, axis_dx, axis_dy, inset)
 {
     var remaining_x = axis_dx;
     var remaining_y = axis_dy;
+    var block_enemy = object_exists(obj_enemy);
 
     // Move X axis
     if (remaining_x != 0)
     {
         var step_x = signNonzero(remaining_x);
+        var blocked_x = false;
         repeat (abs(floor(remaining_x)))
         {
             var next_x = inst.x + step_x;
             if (!pmovePlaceMeetingTilemap(inst, tilemap_id, next_x, inst.y, inset))
+            {
+                var prev_x = inst.x;
                 inst.x = next_x;
+                if (block_enemy)
+                {
+                    var hit_enemy = instance_place(inst.x, inst.y, obj_enemy);
+                    if (hit_enemy != noone)
+                    {
+                        inst.x = prev_x;
+                        blocked_x = true;
+                        break;
+                    }
+                }
+            }
             else
+            {
+                blocked_x = true;
                 break;
+            }
         }
         // Fractional remainder
-        var fract_x = remaining_x - floor(remaining_x);
-        if (fract_x != 0)
+        if (!blocked_x)
         {
-            var next_fx = inst.x + fract_x;
-            if (!pmovePlaceMeetingTilemap(inst, tilemap_id, next_fx, inst.y, inset))
-                inst.x = next_fx;
+            var fract_x = remaining_x - floor(remaining_x);
+            if (fract_x != 0)
+            {
+                var next_fx = inst.x + fract_x;
+                if (!pmovePlaceMeetingTilemap(inst, tilemap_id, next_fx, inst.y, inset))
+                {
+                    var prev_fx = inst.x;
+                    inst.x = next_fx;
+                    if (block_enemy)
+                    {
+                        var hit_enemy_frac = instance_place(inst.x, inst.y, obj_enemy);
+                        if (hit_enemy_frac != noone)
+                        {
+                            inst.x = prev_fx;
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -67,20 +99,51 @@ function pmoveMoveAxis(inst, tilemap_id, axis_dx, axis_dy, inset)
     if (remaining_y != 0)
     {
         var step_y = signNonzero(remaining_y);
+        var blocked_y = false;
         repeat (abs(floor(remaining_y)))
         {
             var next_y = inst.y + step_y;
             if (!pmovePlaceMeetingTilemap(inst, tilemap_id, inst.x, next_y, inset))
+            {
+                var prev_y = inst.y;
                 inst.y = next_y;
+                if (block_enemy)
+                {
+                    var hit_enemy_y = instance_place(inst.x, inst.y, obj_enemy);
+                    if (hit_enemy_y != noone)
+                    {
+                        inst.y = prev_y;
+                        blocked_y = true;
+                        break;
+                    }
+                }
+            }
             else
+            {
+                blocked_y = true;
                 break;
+            }
         }
-        var fract_y = remaining_y - floor(remaining_y);
-        if (fract_y != 0)
+        if (!blocked_y)
         {
-            var next_fy = inst.y + fract_y;
-            if (!pmovePlaceMeetingTilemap(inst, tilemap_id, inst.x, next_fy, inset))
-                inst.y = next_fy;
+            var fract_y = remaining_y - floor(remaining_y);
+            if (fract_y != 0)
+            {
+                var next_fy = inst.y + fract_y;
+                if (!pmovePlaceMeetingTilemap(inst, tilemap_id, inst.x, next_fy, inset))
+                {
+                    var prev_fy = inst.y;
+                    inst.y = next_fy;
+                    if (block_enemy)
+                    {
+                        var hit_enemy_frac_y = instance_place(inst.x, inst.y, obj_enemy);
+                        if (hit_enemy_frac_y != noone)
+                        {
+                            inst.y = prev_fy;
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the control scheme radio buttons read the pending settings state before falling back to cached values so selection updates reliably
- prevent the player mover and enemy mover helpers from stepping into each other so the player and enemies collide instead of overlapping
- remove the player/enemy collision damage handler now that contact damage is disabled

## Testing
- not run (GameMaker runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e63942f40c83329e08c98879079426