### PR TITLE
Prevent enemy melee hitboxes from double damaging players

### DIFF
--- a/objects/obj_enemy_melee_attack/Collision_obj_player.gml
+++ b/objects/obj_enemy_melee_attack/Collision_obj_player.gml
@@ -2,6 +2,13 @@
 * Name: obj_enemy_melee_attack.Collision[obj_player]
 * Description: Damage the player when the slash connects and then expire.
 */
+if (has_triggered)
+{
+    exit;
+}
+
+has_triggered = true;
+
 if (other.damage_cd <= 0)
 {
     other.hp = max(0, other.hp - max(1, damage));

--- a/objects/obj_enemy_melee_attack/Create_0.gml
+++ b/objects/obj_enemy_melee_attack/Create_0.gml
@@ -5,6 +5,7 @@
 damage = 8;
 life   = 8;
 owner  = noone;
+has_triggered = false; // ensure we only damage targets once per hitbox
 
 var _resolved_sprite = enemyConfigResolveAttackSprite();
 if (_resolved_sprite != -1)


### PR DESCRIPTION
## Summary
- add a trigger flag to enemy melee hitboxes when they spawn
- gate the collision logic to ensure each hitbox damages the player at most once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63caf6240833283c13737988e7c66